### PR TITLE
fix(ci): use v9 branch config for python-semantic-release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,10 @@ target-version = "py310"
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
-branch = "main"
 commit_message = "chore: release {version}"
+
+[tool.semantic_release.branches.main]
+match = "main"
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test"]


### PR DESCRIPTION
## Summary

- Replace `branch = "main"` (v7/v8 key) with `[tool.semantic_release.branches.main]` table (v9 key)
- The old key is silently ignored by python-semantic-release v9.15.2, which this repo uses in its release workflow
- This causes the release action to never detect the correct branch and never trigger releases

## Test plan

- [ ] Merge this PR to main
- [ ] Verify the release workflow runs and correctly detects the `main` branch
- [ ] Confirm a new release is created if there are releasable commits (feat/fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)