### PR TITLE
feat: align tray with the hosted workflow lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: uv sync --locked --extra dev
 
       - name: Ruff lint
-        run: uv run ruff check src tests
+        run: uv run ruff check src tests scripts
 
       - name: Build distributions
         run: uv build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,5 +69,6 @@ jobs:
 
       - name: Run tests
         env:
+          PYNPUT_BACKEND: ${{ matrix.os == 'ubuntu-latest' && 'dummy' || '' }}
           PYSTRAY_BACKEND: ${{ matrix.os == 'ubuntu-latest' && 'dummy' || '' }}
         run: uv run --python ${{ matrix.python }} pytest tests -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,4 +68,6 @@ jobs:
         run: uv sync --locked --extra dev --python ${{ matrix.python }}
 
       - name: Run tests
+        env:
+          PYSTRAY_BACKEND: ${{ matrix.os == 'ubuntu-latest' && 'dummy' || '' }}
         run: uv run --python ${{ matrix.python }} pytest tests -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: quality and build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+
+      - name: Install locked dependencies
+        run: uv sync --locked --extra dev
+
+      - name: Ruff lint
+        run: uv run ruff check src tests
+
+      - name: Build distributions
+        run: uv build
+
+  test:
+    name: test (${{ matrix.os }}, Python ${{ matrix.python }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python: "3.10"
+          - os: ubuntu-latest
+            python: "3.11"
+          - os: ubuntu-latest
+            python: "3.12"
+          - os: macos-latest
+            python: "3.12"
+          - os: windows-latest
+            python: "3.12"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ matrix.python }}
+
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+
+      - name: Install locked dependencies
+        run: uv sync --locked --extra dev --python ${{ matrix.python }}
+
+      - name: Run tests
+        run: uv run --python ${{ matrix.python }} pytest tests -q

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,34 +15,36 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Python Semantic Release
         id: release
-        uses: python-semantic-release/python-semantic-release@v9.15.2
+        uses: python-semantic-release/python-semantic-release@7b3f71697ccfbaef884e1e754b6364e974b134cf # v9.15.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build package
+      - name: Verify release workspace
         if: steps.release.outputs.released == 'true'
-        run: uv build
+        run: |
+          uv lock --locked
+          python scripts/check_release_consistency.py --require-dist
 
       - name: Publish to PyPI
         if: steps.release.outputs.released == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
 
       - name: Publish to GitHub Releases
         if: steps.release.outputs.released == 'true'
-        uses: python-semantic-release/publish-action@v9.15.2
+        uses: python-semantic-release/publish-action@b9c41d4b0754dee5a6c7188d42b33f66e3a8aafd # v9.15.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release and PyPI Publish
 
+# Semantic release writes a version commit to protected main, so checkout and
+# publication use the same organization release credential as openadapt-flow.
+
 on:
   push:
     branches:
@@ -18,6 +21,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          token: ${{ secrets.ADMIN_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -31,7 +35,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@7b3f71697ccfbaef884e1e754b6364e974b134cf # v9.15.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.ADMIN_TOKEN }}
 
       - name: Verify release workspace
         if: steps.release.outputs.released == 'true'
@@ -47,4 +51,4 @@ jobs:
         if: steps.release.outputs.released == 'true'
         uses: python-semantic-release/publish-action@b9c41d4b0754dee5a6c7188d42b33f66e3a8aafd # v9.15.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.ADMIN_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 OpenAdapt AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,111 +1,152 @@
 # openadapt-tray
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/downloads/)
 
-<!-- PyPI badges (uncomment once package is published)
-[![PyPI version](https://img.shields.io/pypi/v/openadapt-tray.svg)](https://pypi.org/project/openadapt-tray/)
-[![Downloads](https://img.shields.io/pypi/dm/openadapt-tray.svg)](https://pypi.org/project/openadapt-tray/)
--->
+> **Lifecycle: Experimental supporting surface.** The canonical workflow
+> engine is [`openadapt-flow`](https://github.com/OpenAdaptAI/openadapt-flow).
+> The behavior described below exists on the checked-out
+> `feat/hosted-rewire` branch and is not a generally available integrated
+> desktop release.
 
-A cross-platform system tray application for [OpenAdapt](https://openadapt.ai), providing a graphical interface for controlling recording, monitoring training, and accessing settings without using the command line.
+OpenAdapt Tray is a lightweight status mirror and launcher for the intended
+OpenAdapt desktop authoring experience. It does not record, compile, replay,
+repair, or train models itself. Local actions are delegated to a companion
+desktop process over authenticated loopback IPC; hosted status is read from a
+small needs-attention endpoint.
 
-## Features
+OpenAdapt compiles demonstrated GUI workflows into deterministic, locally
+executable programs. Healthy runs make no model calls. When an interface
+drifts, OpenAdapt re-resolves from recorded evidence or proposes a governed
+repair, and halts when verification fails. That workflow logic belongs to
+`openadapt-flow`, not the tray.
 
-### System Tray Icon
+## Release Boundary
 
-Shows in the menu bar (macOS) or system tray (Windows/Linux) with visual state indicators.
+- Package metadata is currently version `0.0.1` and marks this project
+  pre-alpha.
+- The hosted rewire is branch code. Installing an existing published package
+  must not be assumed to provide the behavior documented here.
+- Unit tests cover the client state machine, IPC framing, menus, and mocked
+  hosted HTTP behavior. They do not prove a working desktop installer, hosted
+  service, or end-to-end authoring loop.
+- The current `openadapt-desktop` main branch does not implement the discovery
+  socket and command contract this tray expects. The two repositories are not
+  integrated end to end in their checked-out state.
 
-![Tray Icon Idle](docs/screenshots/tray-icon-idle.png)
-*Idle state: Blue/gray icon in menu bar*
+## What This Branch Implements
 
-![Tray Icon Recording](docs/screenshots/tray-icon-recording.png)
-*Recording state: Red pulsing icon*
+| Surface | Behavior | Maturity |
+| --- | --- | --- |
+| Recording status | Mirrors start, stop, compiling, and error events received from desktop IPC | Client implemented; companion server unavailable |
+| Recording controls | Sends start/stop commands and can launch `openadapt-desktop` when discovery fails | Client implemented; no compatible released desktop |
+| Workflow shortcuts | Requests the desktop workflow library or teach view | Client implemented; corresponding desktop views unavailable |
+| Sync status | Mirrors synced, syncing, and offline states separately from recording state | Implemented and tested |
+| Needs-attention badge | Polls `GET /api/needs-attention/count` using an ingest token from the environment or OS keychain | Mock-tested client contract; hosted availability not established here |
+| Break routing | Cloud opens the hosted dashboard; connected BYOC opens local teach | Implemented with an important fallback described below |
+| Recent captures | Reads local capture directories; View still tries the legacy `openadapt visualize` command before a file-browser fallback | Transitional behavior |
 
-### Native Notifications
+The retired model-training controls and training states are not part of this
+branch.
 
-Modern notifications with desktop-notifier supporting callbacks and actions.
+## Expected Menu
 
-![Basic Notification](docs/screenshots/notification-basic.png)
-*Example: Recording started notification*
+The menu is built from current local and hosted state:
 
-![Critical Notification](docs/screenshots/notification-critical.png)
-*Example: Error notification with critical urgency*
+```text
+Start Recording (<configured hotkey>)
+Recent Captures
+<N automations need attention>    # only when count > 0
+Open Desktop App
+Open Cloud Dashboard
+Pause Sync / Sync (offline)
+Login...
+Settings...
+Quit
+```
 
-### Other Features
+During a local operation, the recording item changes to Starting, Stop
+Recording, Stopping, or Compiling. These labels reflect events; the tray does
+not perform the work.
 
-- **Status Indicators**: Icon changes color based on application state (idle, recording, training, error)
-- **Start/Stop Recording**: Control capture sessions via menu or global hotkeys
-- **Recent Captures**: Quick access to view or delete recent recordings
-- **Training Control**: Start, monitor, and stop model training
-- **Cross-Platform**: Works on macOS, Windows, and Linux
-- **Lightweight**: Uses pystray (~50KB) instead of heavy Qt dependencies
+## Integration Contract
 
-## Installation
+### Local desktop IPC
+
+The tray discovers a local service from `~/.openadapt/desktop_ipc.json`, then
+uses an authenticated loopback connection. It can send commands to start or
+stop recording, open the workflow library or teach surface, and pause or resume
+sync. It also consumes desktop status events.
+
+If discovery fails, the tray launches `openadapt-desktop` and waits about ten
+seconds for the service. The current desktop package exposes a capture/review
+CLI under that name but does not start the expected IPC service, so this path
+does not currently produce a working integration.
+
+### Hosted needs-attention polling
+
+The poller calls:
+
+```text
+GET <hosted_url>/api/needs-attention/count
+Authorization: Bearer <ingest token>
+```
+
+The token is resolved from `OPENADAPT_INGEST_TOKEN` or the OS keychain and is
+not written to `tray.json`. The default poll interval is 60 seconds, clamped to
+at least 30 seconds, with a slower offline retry.
+
+This is a narrow status endpoint, not hosted execution. The tray does not
+upload screenshots, workflow bundles, or capture artifacts through this
+poller.
+
+### Deployment-lane routing
+
+- `cloud`: a needs-attention click opens
+  `<hosted_url>/dashboard/needs-attention`.
+- `byoc`: while desktop IPC is connected, the click sends `open_teach` locally
+  so workflow data can remain in the customer environment.
+- `byoc` without desktop IPC: the current implementation falls back to the
+  hosted dashboard. Regulated deployments must not treat this fallback as a
+  validated PHI-safe path; it should be changed or policy-gated before
+  production use.
+
+## Development Quickstart
+
+Run this branch as contributor software, not as a production install:
 
 ```bash
-pip install openadapt-tray
+git clone https://github.com/OpenAdaptAI/openadapt-tray.git
+cd openadapt-tray
+git switch feat/hosted-rewire
+
+uv sync --extra dev
+uv run pytest tests -q
+uv run openadapt-tray
 ```
 
-For macOS native experience with enhanced menu bar features:
+Running the process requires a graphical desktop/session. Without a compatible
+desktop IPC server or hosted token it may correctly remain offline, fail local
+actions, or open only browser routes.
+
+For a runnable OpenAdapt workflow, use the canonical engine separately:
 
 ```bash
-pip install openadapt-tray[macos-native]
-```
-
-## Quick Start
-
-```bash
-# Run the tray application
-openadapt-tray
-
-# Or run as a Python module
-python -m openadapt_tray
-```
-
-## Keyboard Shortcuts
-
-| Action | Default Shortcut |
-|--------|------------------|
-| Toggle Recording | `Ctrl+Shift+R` |
-| Open Dashboard | `Ctrl+Shift+D` |
-| Stop Recording | `Ctrl` (triple tap) |
-
-Shortcuts are configurable via the settings file or dashboard.
-
-## Menu Structure
-
-![Menu Structure](docs/screenshots/menu-idle.png)
-*Full menu in idle state*
-
-```
-[OpenAdapt Icon]
-├── Start Recording (Ctrl+Shift+R)
-│   └── [When recording: "Stop Recording (capture-name)"]
-├── ─────────────
-├── Recent Captures
-│   ├── capture-name (2024-01-15 14:30)
-│   │   ├── View
-│   │   └── Delete
-│   └── View All...
-├── Training
-│   ├── Start Training...
-│   └── View Last Results
-├── ─────────────
-├── Open Dashboard
-├── Settings...
-├── ─────────────
-└── Quit
+pip install openadapt-flow
+openadapt-flow demo-record --out rec
+openadapt-flow compile rec --out bundle --name my-task
+openadapt-flow replay bundle
 ```
 
 ## Configuration
 
-Configuration is stored in:
-- **macOS**: `~/Library/Application Support/openadapt/tray.json`
-- **Windows**: `%APPDATA%/openadapt/tray.json`
-- **Linux**: `~/.config/openadapt/tray.json`
+Non-secret settings are stored at:
 
-Example configuration:
+- macOS: `~/Library/Application Support/openadapt/tray.json`
+- Windows: `%APPDATA%/openadapt/tray.json`
+- Linux: `${XDG_CONFIG_HOME:-~/.config}/openadapt/tray.json`
+
+Representative settings:
 
 ```json
 {
@@ -114,108 +155,54 @@ Example configuration:
     "open_dashboard": "<ctrl>+<shift>+d",
     "stop_recording": "<ctrl>+<ctrl>+<ctrl>"
   },
-  "dashboard_port": 8080,
+  "captures_directory": "~/openadapt/captures",
+  "desktop_ipc_port": null,
+  "hosted_url": "https://app.openadapt.ai",
+  "deployment_lane": "cloud",
+  "poll_interval_s": 60,
   "show_notifications": true,
-  "stop_on_triple_ctrl": true,
   "auto_start_on_login": false
 }
 ```
 
-## Development
+`deployment_lane` accepts `cloud` or `byoc`. The ingest token does not belong
+in this file.
 
-### Setup
+## Known Gaps
 
-```bash
-# Clone the repository
-git clone https://github.com/OpenAdaptAI/openadapt-tray.git
-cd openadapt-tray
+- No compatible released desktop IPC server completes the local control path.
+- No packaged installer proves tray startup, permissions, or auto-start across
+  macOS, Windows, and Linux.
+- Hosted polling is tested with mocks; repository tests do not validate a live
+  service contract or service-level commitments.
+- BYOC fallback can open the hosted dashboard when desktop IPC is absent.
+- Recent-capture View still invokes a legacy launcher command.
+- Login opens an ingest-token settings page; the tray does not implement
+  interactive authentication.
+- The tray does not certify workflow safety or verify workflow effects.
 
-# Install in development mode
-pip install -e ".[dev]"
+## Project Structure
+
+```text
+src/openadapt_tray/
+  app.py            tray lifecycle, desktop delegation, and routing
+  ipc.py            authenticated loopback IPC client
+  hosted.py         needs-attention poller and lane routing
+  state.py          recording, sync, and badge state
+  menu.py           state-dependent tray menu
+  keychain.py       ingest-token lookup
+  config.py         non-secret local preferences
+tests/               mocked/unit coverage for these client boundaries
 ```
 
-### Running Tests
+## Related Projects
 
-```bash
-pytest tests/
-```
-
-### Project Structure
-
-```
-openadapt-tray/
-├── src/openadapt_tray/
-│   ├── __init__.py           # Package exports
-│   ├── __main__.py           # Entry point
-│   ├── app.py                # Main TrayApplication class
-│   ├── menu.py               # Menu construction
-│   ├── icons.py              # Icon management
-│   ├── notifications.py      # Cross-platform notifications
-│   ├── shortcuts.py          # Global hotkey handling
-│   ├── config.py             # Configuration management
-│   ├── ipc.py                # Inter-process communication
-│   ├── state.py              # Application state machine
-│   └── platform/
-│       ├── __init__.py       # Platform detection
-│       ├── base.py           # Abstract base class
-│       ├── macos.py          # macOS-specific
-│       ├── windows.py        # Windows-specific
-│       └── linux.py          # Linux-specific
-├── assets/
-│   ├── icons/                # State icons (idle, recording, etc.)
-│   └── logo.ico              # Windows icon
-├── tests/                    # Test suite
-├── pyproject.toml
-└── README.md
-```
-
-## Dependencies
-
-- **pystray** (>=0.19.0): Cross-platform system tray
-- **Pillow** (>=9.0.0): Icon handling
-- **pynput** (>=1.7.0): Global hotkeys
-- **click** (>=8.0.0): CLI integration
-- **desktop-notifier** (>=6.2.0): Modern native notifications
-
-## Integration
-
-The tray application delegates to the `openadapt` CLI for all operations:
-
-```bash
-# Commands executed by the tray app
-openadapt record <name>          # Start recording
-openadapt visualize <path>       # View capture
-openadapt train start            # Start training
-openadapt train status           # Get training status
-```
-
-## Platform Notes
-
-### macOS
-- Hides from the Dock, appears only in the menu bar
-- Native dialogs via AppleScript
-- Auto-start via Launch Agents
-
-### Windows
-- Appears in the system tray
-- Native dialogs via ctypes/tkinter
-- Auto-start via Registry
-
-### Linux
-- Requires a desktop environment with system tray support
-- Dialogs via zenity, kdialog, or tkinter
-- Auto-start via XDG autostart
+| Project | Lifecycle and role |
+| --- | --- |
+| [`openadapt-flow`](https://github.com/OpenAdaptAI/openadapt-flow) | Canonical workflow compiler, runtime, certification, and governed repair engine |
+| [`openadapt-desktop`](https://github.com/OpenAdaptAI/openadapt-desktop) | Experimental authoring/teaching direction; current main is not IPC-compatible with this branch |
+| [`OpenAdapt`](https://github.com/OpenAdaptAI/OpenAdapt) | Flagship launcher/meta-repository |
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) for details.
-
-## Contributing
-
-Contributions are welcome! Please see our [contributing guidelines](https://github.com/OpenAdaptAI/OpenAdapt/blob/main/CONTRIBUTING.md).
-
-## Links
-
-- [OpenAdapt Website](https://openadapt.ai)
-- [OpenAdapt Documentation](https://docs.openadapt.ai)
-- [GitHub Repository](https://github.com/OpenAdaptAI/openadapt-tray)
+MIT. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ poller.
 ### Deployment-lane routing
 
 - `cloud`: a needs-attention click opens
-  `<hosted_url>/dashboard/needs-attention`.
+  `<hosted_url>/dashboard`, which lists open halts and uncertain dispatches.
 - `byoc`: while desktop IPC is connected, the click sends `open_teach` locally
   so workflow data can remain in the customer environment.
 - `byoc` without desktop IPC: the current implementation falls back to the

--- a/generate_screenshots.py
+++ b/generate_screenshots.py
@@ -15,11 +15,11 @@ Requirements:
 Screenshots to capture:
     1. Tray icon (idle state)
     2. Tray icon (recording state)
-    3. Tray icon (training state)
-    4. Tray icon (error state)
-    5. Basic notification popup
-    6. Critical notification popup
-    7. Notification with callback
+    3. Tray icon (compiling state)
+    4. Tray icon (break badge — automations need attention)
+    5. Tray icon (error state)
+    6. Basic notification popup
+    7. Needs-attention notification popup
     8. Menu structure
     9. Notification Center with grouped notifications
     10. Settings/configuration (if available)
@@ -98,26 +98,26 @@ def main():
             "instructions": "Capture: Notification popup (Recording Started)"
         },
         {
-            "name": "03-critical-notification",
-            "description": "Critical/error notification",
+            "name": "03-needs-attention-notification",
+            "description": "Needs-attention notification (break badge source)",
             "action": lambda: notifications.show(
-                "Error",
-                "Screen capture permission denied. Please enable in System Preferences.",
-                urgency="critical"
+                "Automations need attention",
+                "2 automations need attention",
+                urgency="critical",
+                on_clicked=lambda: print("  → Click routes to needs-attention"),
             ),
             "wait": 2,
-            "instructions": "Capture: Critical notification (Error) - should look different"
+            "instructions": "Capture: Needs-attention notification (critical urgency)"
         },
         {
-            "name": "04-callback-notification",
-            "description": "Notification with action callback",
+            "name": "04-compiling-notification",
+            "description": "Compiling notification (recording → workflow)",
             "action": lambda: notifications.show(
-                "Training Complete",
-                "Click to view results in dashboard",
-                on_clicked=lambda: print("  → Callback would open dashboard")
+                "Compiling",
+                "Building a workflow from: my-workflow",
             ),
             "wait": 2,
-            "instructions": "Capture: Notification with action (Training Complete)"
+            "instructions": "Capture: Compiling notification"
         },
         {
             "name": "05-multiple-notifications",
@@ -137,14 +137,21 @@ def main():
             "description": "Tray icon in RECORDING state",
             "action": lambda: print("  → NOTE: Recording icon requires running tray app"),
             "wait": 2,
-            "instructions": "Capture: Recording icon (red pulsing - requires running app)"
+            "instructions": "Capture: Recording icon (red - requires running app)"
         },
         {
-            "name": "07-training-icon",
-            "description": "Tray icon in TRAINING state",
-            "action": lambda: print("  → NOTE: Training icon requires running tray app"),
+            "name": "07-compiling-icon",
+            "description": "Tray icon in COMPILING state",
+            "action": lambda: print("  → NOTE: Compiling icon requires running tray app"),
             "wait": 2,
-            "instructions": "Capture: Training icon (purple gear - requires running app)"
+            "instructions": "Capture: Compiling icon (purple - requires running app)"
+        },
+        {
+            "name": "07b-break-badge-icon",
+            "description": "Tray icon with break badge (needs attention)",
+            "action": lambda: print("  → NOTE: Badge icon requires running tray app with break_count > 0"),
+            "wait": 2,
+            "instructions": "Capture: Idle/recording icon with red break badge dot"
         },
         {
             "name": "08-error-icon",
@@ -212,7 +219,7 @@ def main():
     print("  4. Create GIF animations (optional)")
     print()
     print("Recommended screenshots still needed:")
-    print("  • Tray icon states (recording, training, error) - requires running app")
+    print("  • Tray icon states (recording, compiling, break-badge, error) - requires running app")
     print("  • Menu structure - requires running app")
     print("  • Settings UI - if implemented")
     print()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,8 @@ target-version = "py310"
 version_toml = ["pyproject.toml:project.version"]
 version_variables = ["src/openadapt_tray/__init__.py:__version__"]
 commit_message = "chore: release {version}"
+# Keep Experimental releases pre-1.0 until API stability is declared.
+major_on_zero = false
 build_command = """
 python -m pip install --disable-pip-version-check -e '.[release]'
 uv lock --upgrade-package "$PACKAGE_NAME"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
     "pynput>=1.7.0",
     "click>=8.0.0",
     "desktop-notifier>=6.2.0",
+    "httpx>=0.27",
+    "keyring>=24.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,16 @@
 [project]
 name = "openadapt-tray"
 version = "0.0.1"
-description = "System tray application for OpenAdapt"
+description = "Experimental status and launcher companion for OpenAdapt workflow authoring and governed repair"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 authors = [
     {name = "MLDSAI Inc.", email = "richard@mldsai.com"}
 ]
-keywords = ["gui", "system-tray", "menu-bar", "openadapt"]
+keywords = ["gui", "system-tray", "menu-bar", "workflow-automation", "openadapt"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: MacOS",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ dev = [
     "pytest-mock>=3.10.0",
     "ruff>=0.1.0",
 ]
+release = [
+    "uv==0.11.26",
+]
 all = [
     "openadapt-tray[macos-native]",
 ]
@@ -70,7 +73,14 @@ target-version = "py310"
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
+version_variables = ["src/openadapt_tray/__init__.py:__version__"]
 commit_message = "chore: release {version}"
+build_command = """
+python -m pip install --disable-pip-version-check -e '.[release]'
+uv lock --upgrade-package "$PACKAGE_NAME"
+git add uv.lock
+uv build --wheel --sdist
+"""
 
 [tool.semantic_release.branches.main]
 match = "main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ version_toml = ["pyproject.toml:project.version"]
 version_variables = ["src/openadapt_tray/__init__.py:__version__"]
 commit_message = "chore: release {version}"
 # Keep Experimental releases pre-1.0 until API stability is declared.
+allow_zero_version = true
 major_on_zero = false
 build_command = """
 python -m pip install --disable-pip-version-check -e '.[release]'

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Check that release version sources and built distributions agree."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _match(pattern: str, text: str, source: str) -> str:
+    match = re.search(pattern, text, flags=re.MULTILINE)
+    if not match:
+        raise ValueError(f"could not read version from {source}")
+    return match.group(1)
+
+
+def release_versions() -> dict[str, str]:
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    package_init = (ROOT / "src/openadapt_tray/__init__.py").read_text(
+        encoding="utf-8"
+    )
+    lock = (ROOT / "uv.lock").read_text(encoding="utf-8")
+
+    return {
+        "pyproject.toml": _match(
+            r"\[project\]\s+name = \"openadapt-tray\"\s+version = \"([^\"]+)\"",
+            pyproject,
+            "pyproject.toml",
+        ),
+        "src/openadapt_tray/__init__.py": _match(
+            r'^__version__ = "([^"]+)"$', package_init, "package __init__"
+        ),
+        "uv.lock": _match(
+            r"\[\[package\]\]\s+name = \"openadapt-tray\"\s+version = \"([^\"]+)\""
+            r"\s+source = \{ editable = \"\.\" \}",
+            lock,
+            "uv.lock",
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--require-dist", action="store_true")
+    args = parser.parse_args()
+
+    versions = release_versions()
+    unique_versions = set(versions.values())
+    if len(unique_versions) != 1:
+        parser.error(f"release versions differ: {versions}")
+    version = unique_versions.pop()
+
+    if args.require_dist:
+        distributions = list((ROOT / "dist").glob(f"openadapt_tray-{version}*"))
+        names = [path.name for path in distributions]
+        if not any(name.endswith(".whl") for name in names) or not any(
+            name.endswith(".tar.gz") for name in names
+        ):
+            parser.error(
+                f"missing wheel or source distribution for {version}: {distributions}"
+            )
+
+    print(f"Release version {version} is synchronized across project, module, and lock.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_icons.py
+++ b/scripts/generate_icons.py
@@ -87,7 +87,7 @@ def main():
 
     ico_path = OUTPUT_DIR.parent / "logo.ico"
     create_ico_file(ico_images, ico_path)
-    print(f"  Created logo.ico")
+    print("  Created logo.ico")
 
     print("Done!")
 

--- a/src/openadapt_tray/__init__.py
+++ b/src/openadapt_tray/__init__.py
@@ -3,14 +3,18 @@
 __version__ = "0.1.0"
 
 from openadapt_tray.app import TrayApplication, main
-from openadapt_tray.state import TrayState, AppState, StateManager
+from openadapt_tray.state import TrayState, SyncState, AppState, StateManager
 from openadapt_tray.config import TrayConfig
+from openadapt_tray.hosted import HostedPoller, CountResult
 
 __all__ = [
     "TrayApplication",
     "TrayState",
+    "SyncState",
     "AppState",
     "StateManager",
     "TrayConfig",
+    "HostedPoller",
+    "CountResult",
     "main",
 ]

--- a/src/openadapt_tray/__init__.py
+++ b/src/openadapt_tray/__init__.py
@@ -1,6 +1,6 @@
 """OpenAdapt Tray - System tray application for OpenAdapt."""
 
-__version__ = "0.1.0"
+__version__ = "0.0.1"
 
 from openadapt_tray.app import TrayApplication, main
 from openadapt_tray.state import TrayState, SyncState, AppState, StateManager

--- a/src/openadapt_tray/app.py
+++ b/src/openadapt_tray/app.py
@@ -1,4 +1,13 @@
-"""Main system tray application for OpenAdapt."""
+"""Main system tray application for OpenAdapt.
+
+The tray is a lightweight status mirror + launcher. It owns no business logic:
+
+* recording/compile actions are commands sent to the **desktop app** over a
+  loopback socket (discovered via ``~/.openadapt/desktop_ipc.json``);
+* the **break badge** is polled from the hosted control plane's
+  needs-attention count endpoint;
+* the desktop app is the source of truth for all state — the tray renders it.
+"""
 
 import sys
 import threading
@@ -7,16 +16,26 @@ import webbrowser
 from typing import Optional
 
 import pystray
-from PIL import Image
 
-from openadapt_tray.state import StateManager, TrayState, AppState
+from openadapt_tray.state import (
+    StateManager,
+    TrayState,
+    SyncState,
+    AppState,
+    LANE_BYOC,
+    LANE_CLOUD,
+)
 from openadapt_tray.menu import MenuBuilder
 from openadapt_tray.icons import IconManager
 from openadapt_tray.shortcuts import HotkeyManager
 from openadapt_tray.notifications import NotificationManager
 from openadapt_tray.ipc import IPCClient, IPCMessageType
 from openadapt_tray.config import TrayConfig
+from openadapt_tray.hosted import HostedPoller, CountResult, route_break_click
 from openadapt_tray.platform import get_platform_handler
+
+# How the tray launches the desktop app when the socket is unreachable.
+DESKTOP_APP_COMMAND = "openadapt-desktop"
 
 
 class TrayApplication:
@@ -32,15 +51,29 @@ class TrayApplication:
         self.state = StateManager()
         self.platform = get_platform_handler()
 
+        # Seed the deployment lane from config so break-click routing is correct
+        # before the desktop first reports it.
+        self.state.set_deployment_lane(self.config.deployment_lane)
+
         # Initialize components
         self.icons = IconManager()
         self.notifications = NotificationManager()
         self.menu_builder = MenuBuilder(self)
         self.hotkeys = HotkeyManager(self.config.hotkeys)
-        self.ipc = IPCClient()
 
-        # Process handle for capture subprocess
-        self._capture_process: Optional[subprocess.Popen] = None
+        # IPC client — configured from the desktop discovery file when present.
+        self.ipc = IPCClient.from_discovery() or IPCClient(
+            port=self.config.desktop_ipc_port or IPCClient.DEFAULT_PORT,
+        )
+
+        # Cloud needs-attention poller (started in run()).
+        self.hosted = HostedPoller(
+            config=self.config,
+            on_count=self._on_hosted_count,
+            notifier=self.notifications,
+            on_break_clicked=self.open_needs_attention,
+            set_offline=self._on_hosted_offline,
+        )
 
         # Create tray icon
         self.icon = pystray.Icon(
@@ -70,7 +103,7 @@ class TrayApplication:
         )
         self.hotkeys.register(
             self.config.hotkeys.open_dashboard,
-            self._open_dashboard,
+            self.open_desktop_app,
         )
 
         # Register triple-ctrl for stop recording (legacy compatibility)
@@ -81,7 +114,7 @@ class TrayApplication:
             )
 
     def _setup_ipc_handlers(self) -> None:
-        """Configure IPC message handlers."""
+        """Configure IPC message handlers (desktop → tray events)."""
         self.ipc.register_handler(
             IPCMessageType.RECORDING_STARTED,
             self._on_ipc_recording_started,
@@ -99,8 +132,16 @@ class TrayApplication:
             self._on_ipc_status_update,
         )
         self.ipc.register_handler(
-            IPCMessageType.TRAINING_PROGRESS,
-            self._on_ipc_training_progress,
+            IPCMessageType.COMPILE_PROGRESS,
+            self._on_ipc_compile_progress,
+        )
+        self.ipc.register_handler(
+            IPCMessageType.SYNC_STATE,
+            self._on_ipc_sync_state,
+        )
+        self.ipc.register_handler(
+            IPCMessageType.BREAK_COUNT,
+            self._on_ipc_break_count,
         )
 
     def _on_state_change(self, state: AppState) -> None:
@@ -109,8 +150,8 @@ class TrayApplication:
         Args:
             state: New application state.
         """
-        # Update icon
-        self.icon.icon = self.icons.get(state.state)
+        # Update icon (with break badge when automations need attention).
+        self.icon.icon = self.icons.get(state.state, break_count=state.break_count)
 
         # Update menu
         self.icon.menu = self.menu_builder.build()
@@ -120,7 +161,7 @@ class TrayApplication:
             self._show_state_notification(state)
 
     def _show_state_notification(self, state: AppState) -> None:
-        """Show notification for state transitions.
+        """Show notification for recording-lifecycle transitions.
 
         Args:
             state: Current application state.
@@ -130,8 +171,11 @@ class TrayApplication:
                 "Recording Started",
                 f"Capturing: {state.current_capture or 'session'}",
             ),
+            TrayState.COMPILING: (
+                "Compiling",
+                f"Building a workflow from: {state.current_capture or 'recording'}",
+            ),
             TrayState.IDLE: ("Recording Stopped", "Capture saved"),
-            TrayState.TRAINING: ("Training Started", "Model training in progress"),
             TrayState.ERROR: ("Error", state.error_message or "An error occurred"),
         }
 
@@ -155,11 +199,56 @@ class TrayApplication:
         if self.state.current.can_stop_recording():
             self.stop_recording()
 
+    # --- desktop connection -------------------------------------------------
+
+    def ensure_desktop_connection(self) -> bool:
+        """Ensure the tray is connected to the desktop loopback socket.
+
+        If the desktop app is not running (no discovery file / unreachable),
+        launch it, wait briefly for the discovery file, then connect.
+
+        Returns:
+            True if connected.
+        """
+        if self.ipc.is_connected():
+            return True
+
+        # Try discovery + connect first (desktop may already be up).
+        if self.ipc.refresh_from_discovery() and self.ipc.connect():
+            return True
+
+        # Desktop not running — launch it, then poll for the discovery file.
+        self._launch_desktop_app()
+        for _ in range(20):  # ~10s
+            if self.ipc.refresh_from_discovery() and self.ipc.connect():
+                return True
+            threading.Event().wait(0.5)
+
+        return False
+
+    def _launch_desktop_app(self) -> None:
+        """Spawn the desktop app process (best-effort)."""
+        try:
+            subprocess.Popen(
+                [DESKTOP_APP_COMMAND],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except FileNotFoundError:
+            self.notifications.show(
+                "Desktop app not found",
+                "Install the OpenAdapt desktop app to record and manage workflows.",
+            )
+        except Exception as e:
+            print(f"Failed to launch desktop app: {e}")
+
+    # --- recording actions (delegated to the desktop over IPC) --------------
+
     def start_recording(self, name: Optional[str] = None) -> None:
-        """Start a new capture session.
+        """Start a new capture session via the desktop app.
 
         Args:
-            name: Optional name for the capture. If None, prompts user.
+            name: Optional name for the capture. If None, prompts the user.
         """
         if not self.state.current.can_start_recording():
             return
@@ -181,73 +270,104 @@ class TrayApplication:
 
         self.state.transition(TrayState.RECORDING_STARTING, current_capture=name)
 
-        # Start capture in background thread
+        # Connect + dispatch on a background thread (launching the desktop app
+        # may take a few seconds).
         threading.Thread(
-            target=self._run_capture,
+            target=self._dispatch_start_recording,
             args=(name,),
             daemon=True,
         ).start()
 
-    def _run_capture(self, name: str) -> None:
-        """Run capture in background thread.
-
-        Args:
-            name: Capture session name.
-        """
-        try:
-            # Start capture via CLI subprocess
-            self._capture_process = subprocess.Popen(
-                ["openadapt", "record", name],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-            self.state.transition(TrayState.RECORDING, current_capture=name)
-
-            # Wait for process to complete (when stopped externally)
-            self._capture_process.wait()
-
-            # Check if we're still in recording state (vs explicit stop)
-            if self.state.current.state == TrayState.RECORDING:
-                self.state.transition(TrayState.IDLE)
-
-        except FileNotFoundError:
+    def _dispatch_start_recording(self, name: str) -> None:
+        """Ensure the desktop is up and send the start-recording command."""
+        if not self.ensure_desktop_connection():
             self.state.transition(
                 TrayState.ERROR,
-                error_message="openadapt CLI not found. Please install openadapt.",
+                error_message="Could not reach the desktop app to start recording.",
             )
-        except Exception as e:
-            self.state.transition(TrayState.ERROR, error_message=str(e))
+            return
+        if not self.ipc.send_start_recording(name):
+            self.state.transition(
+                TrayState.ERROR,
+                error_message="Failed to send start-recording command.",
+            )
+        # The desktop confirms via a RECORDING_STARTED event.
 
     def stop_recording(self) -> None:
-        """Stop the current capture session."""
+        """Stop the current capture session via the desktop app."""
         if not self.state.current.can_stop_recording():
             return
 
         self.state.transition(TrayState.RECORDING_STOPPING)
+        self.ipc.send_stop_recording()
+        # The desktop confirms via RECORDING_STOPPED (then COMPILE_PROGRESS).
 
-        # Terminate capture process
-        if self._capture_process and self._capture_process.poll() is None:
-            try:
-                # Send SIGTERM for graceful shutdown
-                self._capture_process.terminate()
+    # --- quick actions ------------------------------------------------------
 
-                # Wait briefly for process to cleanup
-                try:
-                    self._capture_process.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    # Force kill if not responding
-                    self._capture_process.kill()
-            except Exception as e:
-                print(f"Error stopping capture process: {e}")
+    def open_desktop_app(self) -> None:
+        """Open (or focus) the desktop app's workflow library."""
+        if self.ipc.is_connected():
+            self.ipc.send_open_workflow_library()
+            return
+        # Not connected — launch/connect, then ask it to open the library.
+        threading.Thread(
+            target=self._open_desktop_app_async,
+            daemon=True,
+        ).start()
 
-        self._capture_process = None
-        self.state.transition(TrayState.IDLE)
+    def _open_desktop_app_async(self) -> None:
+        """Background helper for :meth:`open_desktop_app`."""
+        if self.ensure_desktop_connection():
+            self.ipc.send_open_workflow_library()
 
-    def _open_dashboard(self) -> None:
-        """Open the web dashboard."""
-        webbrowser.open(f"http://localhost:{self.config.dashboard_port}")
+    def open_cloud_dashboard(self) -> None:
+        """Open the hosted cloud dashboard in the system browser."""
+        webbrowser.open(self.config.hosted_url)
 
-    # IPC event handlers
+    def open_needs_attention(self) -> None:
+        """Route a needs-attention click by deployment lane (§3c)."""
+        route_break_click(
+            self.config,
+            ipc_client=self.ipc if self.ipc.is_connected() else None,
+        )
+
+    def login(self) -> None:
+        """Start the hosted login flow.
+
+        The tray does not implement auth; it opens the ingest-token settings
+        page (the desktop app owns the interactive providers) so the user can
+        mint/paste a token that lands in the shared keychain.
+        """
+        webbrowser.open(
+            f"{self.config.hosted_url.rstrip('/')}/dashboard/settings/ingest"
+        )
+
+    def pause_sync(self) -> None:
+        """Ask the desktop to pause the upload/sync queue."""
+        if self.ipc.is_connected():
+            self.ipc.send_pause_sync()
+        self.state.set_sync_state(SyncState.SYNCED)
+
+    def resume_sync(self) -> None:
+        """Ask the desktop to resume the upload/sync queue."""
+        if self.ipc.is_connected():
+            self.ipc.send_resume_sync()
+
+    # --- hosted poller callbacks --------------------------------------------
+
+    def _on_hosted_count(self, result: CountResult) -> None:
+        """Apply a needs-attention count from the cloud poller."""
+        self.state.set_break_count(result.count)
+
+    def _on_hosted_offline(self, offline: bool) -> None:
+        """Reflect the cloud poller's online/offline status on the sync channel."""
+        if offline:
+            self.state.set_sync_state(SyncState.OFFLINE)
+        elif self.state.current.is_offline():
+            # Recovered connectivity — clear the offline marker.
+            self.state.set_sync_state(SyncState.SYNCED)
+
+    # --- IPC event handlers (desktop → tray) --------------------------------
 
     def _on_ipc_recording_started(self, message) -> None:
         """Handle recording started IPC event."""
@@ -270,18 +390,67 @@ class TrayApplication:
         )
 
     def _on_ipc_status_update(self, message) -> None:
-        """Handle status update IPC event."""
-        # Generic status updates - could update UI or log
-        pass
+        """Handle a full status update from the desktop (source of truth).
 
-    def _on_ipc_training_progress(self, message) -> None:
-        """Handle training progress IPC event."""
+        The payload may carry ``state``, ``deployment_lane``, ``sync_state``,
+        ``break_count`` and ``offline``.
+        """
         data = message.data or {}
-        progress = data.get("progress", 0)
-        self.state.transition(
-            TrayState.TRAINING,
-            training_progress=progress,
-        )
+
+        lane = data.get("deployment_lane")
+        if lane in (LANE_CLOUD, LANE_BYOC):
+            self.state.set_deployment_lane(lane)
+
+        sync = data.get("sync_state")
+        if sync is not None:
+            self._apply_sync_state(sync)
+
+        if "break_count" in data:
+            self.state.set_break_count(data.get("break_count") or 0)
+
+        state_name = data.get("state")
+        if state_name:
+            try:
+                self.state.transition(TrayState[state_name])
+            except KeyError:
+                pass
+
+    def _on_ipc_compile_progress(self, message) -> None:
+        """Handle a compile-progress event (recording → workflow)."""
+        data = message.data or {}
+        # Any progress signal means we are compiling; a terminal signal returns
+        # to idle.
+        if data.get("done"):
+            self.state.transition(TrayState.IDLE)
+        else:
+            self.state.transition(
+                TrayState.COMPILING,
+                current_capture=data.get("name"),
+            )
+
+    def _on_ipc_sync_state(self, message) -> None:
+        """Handle a sync-state event from the desktop."""
+        data = message.data or {}
+        self._apply_sync_state(data.get("state"))
+
+    def _on_ipc_break_count(self, message) -> None:
+        """Handle a break-count event pushed from the desktop."""
+        data = message.data or {}
+        self.state.set_break_count(data.get("count") or 0)
+
+    def _apply_sync_state(self, name: Optional[str]) -> None:
+        """Map a sync-state name from IPC onto the SyncState channel."""
+        if not name:
+            return
+        mapping = {
+            "synced": SyncState.SYNCED,
+            "syncing": SyncState.SYNCING,
+            "pushing": SyncState.SYNCING,
+            "offline": SyncState.OFFLINE,
+        }
+        sync = mapping.get(str(name).lower())
+        if sync is not None:
+            self.state.set_sync_state(sync)
 
     def run(self) -> None:
         """Run the application."""
@@ -291,15 +460,17 @@ class TrayApplication:
         # Platform-specific setup
         self.platform.setup()
 
-        # Try to connect to IPC server (optional - won't block if unavailable)
+        # Try to connect to the desktop IPC server (optional — non-blocking).
         try:
-            connected = self.ipc.connect()
-            if connected:
-                print("IPC connected successfully")
+            if self.ipc.refresh_from_discovery() and self.ipc.connect():
+                print("Connected to desktop app IPC")
             else:
-                print("IPC server not available - running in standalone mode")
+                print("Desktop app not running — will launch on first action")
         except Exception as e:
             print(f"IPC connection failed: {e} - running in standalone mode")
+
+        # Start the cloud needs-attention poller.
+        self.hosted.start()
 
         # Run the tray icon (blocks)
         self.icon.run()
@@ -311,6 +482,7 @@ class TrayApplication:
             self.stop_recording()
 
         # Cleanup components
+        self.hosted.stop()
         self.hotkeys.stop()
         self.ipc.close()
         self.notifications.cleanup()

--- a/src/openadapt_tray/config.py
+++ b/src/openadapt_tray/config.py
@@ -1,28 +1,47 @@
 """Configuration management for OpenAdapt Tray."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import Optional, Any, Dict
 import json
 import os
 
 from openadapt_tray.shortcuts import HotkeyConfig
+from openadapt_tray import keychain
+
+# Sane bounds for the cloud needs-attention poll (spec §3c).
+MIN_POLL_INTERVAL_S = 30
+DEFAULT_POLL_INTERVAL_S = 60
+OFFLINE_POLL_INTERVAL_S = 300
 
 
 @dataclass
 class TrayConfig:
-    """Tray application configuration."""
+    """Tray application configuration.
+
+    Non-secret UI/behaviour prefs persist to the platform ``tray.json``. The
+    hosted host + deployment lane are ALSO surfaced here so all local surfaces
+    agree, but the ingest **token** is NEVER stored here — it is read from the
+    OS keychain (see :mod:`openadapt_tray.keychain`).
+    """
 
     # Hotkeys
     hotkeys: HotkeyConfig = field(default_factory=HotkeyConfig)
 
     # Paths
     captures_directory: str = "~/openadapt/captures"
-    training_output_directory: str = "~/openadapt/training"
 
-    # Dashboard
+    # Desktop app (local loopback IPC). The port is normally discovered from
+    # ``~/.openadapt/desktop_ipc.json``; this is an optional override/fallback.
     dashboard_port: int = 8080
     auto_launch_dashboard: bool = True
+    desktop_ipc_port: Optional[int] = None
+
+    # Hosted control plane (cloud). ``deployment_lane`` drives lane-aware
+    # break-click routing (cloud → dashboard; byoc → local teach).
+    hosted_url: str = "https://app.openadapt.ai"
+    deployment_lane: str = "cloud"  # "cloud" | "byoc"
+    poll_interval_s: int = DEFAULT_POLL_INTERVAL_S
 
     # Behavior
     auto_start_on_login: bool = False
@@ -69,7 +88,12 @@ class TrayConfig:
 
     @classmethod
     def _from_dict(cls, data: Dict[str, Any]) -> "TrayConfig":
-        """Create a TrayConfig from a dictionary."""
+        """Create a TrayConfig from a dictionary.
+
+        Unknown/stale keys (e.g. the retired ``training_output_directory``) are
+        ignored so upgrading over an old ``tray.json`` never crashes.
+        """
+        data = dict(data)  # don't mutate caller's dict
         hotkeys_data = data.pop("hotkeys", {})
         hotkeys = HotkeyConfig(
             toggle_recording=hotkeys_data.get(
@@ -83,7 +107,9 @@ class TrayConfig:
             ),
         )
 
-        return cls(hotkeys=hotkeys, **data)
+        known = {f.name for f in fields(cls) if f.name != "hotkeys"}
+        filtered = {k: v for k, v in data.items() if k in known}
+        return cls(hotkeys=hotkeys, **filtered)
 
     def save(self) -> None:
         """Save configuration to file."""
@@ -94,7 +120,7 @@ class TrayConfig:
         path.write_text(json.dumps(data, indent=2))
 
     def to_dict(self) -> Dict[str, Any]:
-        """Convert configuration to a dictionary."""
+        """Convert configuration to a dictionary (non-secret prefs only)."""
         return {
             "hotkeys": {
                 "toggle_recording": self.hotkeys.toggle_recording,
@@ -102,9 +128,12 @@ class TrayConfig:
                 "stop_recording": self.hotkeys.stop_recording,
             },
             "captures_directory": self.captures_directory,
-            "training_output_directory": self.training_output_directory,
             "dashboard_port": self.dashboard_port,
             "auto_launch_dashboard": self.auto_launch_dashboard,
+            "desktop_ipc_port": self.desktop_ipc_port,
+            "hosted_url": self.hosted_url,
+            "deployment_lane": self.deployment_lane,
+            "poll_interval_s": self.poll_interval_s,
             "auto_start_on_login": self.auto_start_on_login,
             "minimize_to_tray": self.minimize_to_tray,
             "show_notifications": self.show_notifications,
@@ -119,6 +148,10 @@ class TrayConfig:
         """Get the expanded captures directory path."""
         return Path(self.captures_directory).expanduser()
 
-    def get_training_path(self) -> Path:
-        """Get the expanded training output directory path."""
-        return Path(self.training_output_directory).expanduser()
+    def effective_poll_interval_s(self) -> int:
+        """Return the configured poll interval, clamped to the safe minimum."""
+        return max(MIN_POLL_INTERVAL_S, int(self.poll_interval_s))
+
+    def get_ingest_token(self) -> Optional[str]:
+        """Resolve the hosted ingest token from env/keychain (never the file)."""
+        return keychain.get_ingest_token(self.hosted_url)

--- a/src/openadapt_tray/hosted.py
+++ b/src/openadapt_tray/hosted.py
@@ -8,10 +8,10 @@ Contract (spec §3c) — the exact request this module issues::
 
     GET {hosted_url}/api/needs-attention/count
     Authorization: Bearer <ingest token>
-    → 200 { "count": <int>, "open_halts": <int>, "failed_runs": <int> }
+    → 200 { "count": <int>, "halts": <int>, "uncertain_dispatches": <int> }
 
 Click routing is lane-aware:
-  * cloud lane → open ``{hosted_url}/dashboard/needs-attention`` in the browser
+  * cloud lane → open ``{hosted_url}/dashboard`` in the browser
   * byoc lane  → IPC ``open_teach`` to the desktop (the fix stays local)
 """
 
@@ -37,16 +37,16 @@ class CountResult:
     """Parsed response from the needs-attention count endpoint."""
 
     count: int
-    open_halts: int = 0
-    failed_runs: int = 0
+    halts: int = 0
+    uncertain_dispatches: int = 0
 
     @classmethod
     def from_payload(cls, payload: dict) -> "CountResult":
         """Build a result from the JSON body, tolerating missing subfields."""
         return cls(
             count=int(payload.get("count", 0)),
-            open_halts=int(payload.get("open_halts", 0)),
-            failed_runs=int(payload.get("failed_runs", 0)),
+            halts=int(payload.get("halts", 0)),
+            uncertain_dispatches=int(payload.get("uncertain_dispatches", 0)),
         )
 
 
@@ -224,4 +224,4 @@ def route_break_click(
             except Exception as e:
                 print(f"Failed to route byoc break click to desktop: {e}")
         # Fall through to the dashboard if the desktop is unreachable.
-    webbrowser.open(f"{config.hosted_url.rstrip('/')}/dashboard/needs-attention")
+    webbrowser.open(f"{config.hosted_url.rstrip('/')}/dashboard")

--- a/src/openadapt_tray/hosted.py
+++ b/src/openadapt_tray/hosted.py
@@ -1,0 +1,227 @@
+"""Cloud needs-attention poller for OpenAdapt Tray.
+
+Polls the hosted control plane for the number of automations that need
+attention and surfaces it as a tray badge + a desktop notification when the
+count rises. Authenticated with the ingest bearer token from the OS keychain.
+
+Contract (spec §3c) — the exact request this module issues::
+
+    GET {hosted_url}/api/needs-attention/count
+    Authorization: Bearer <ingest token>
+    → 200 { "count": <int>, "open_halts": <int>, "failed_runs": <int> }
+
+Click routing is lane-aware:
+  * cloud lane → open ``{hosted_url}/dashboard/needs-attention`` in the browser
+  * byoc lane  → IPC ``open_teach`` to the desktop (the fix stays local)
+"""
+
+import threading
+import webbrowser
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import httpx
+
+from openadapt_tray.config import (
+    TrayConfig,
+    MIN_POLL_INTERVAL_S,
+    OFFLINE_POLL_INTERVAL_S,
+)
+
+COUNT_ENDPOINT_PATH = "/api/needs-attention/count"
+REQUEST_TIMEOUT_S = 10.0
+
+
+@dataclass
+class CountResult:
+    """Parsed response from the needs-attention count endpoint."""
+
+    count: int
+    open_halts: int = 0
+    failed_runs: int = 0
+
+    @classmethod
+    def from_payload(cls, payload: dict) -> "CountResult":
+        """Build a result from the JSON body, tolerating missing subfields."""
+        return cls(
+            count=int(payload.get("count", 0)),
+            open_halts=int(payload.get("open_halts", 0)),
+            failed_runs=int(payload.get("failed_runs", 0)),
+        )
+
+
+def count_url(hosted_url: str) -> str:
+    """Return the fully-qualified count endpoint URL for a hosted host."""
+    return f"{hosted_url.rstrip('/')}{COUNT_ENDPOINT_PATH}"
+
+
+class HostedPoller:
+    """Background poller for the cloud needs-attention count.
+
+    The poller is transport-thin and testable: :meth:`poll_once` performs a
+    single authenticated request and returns a :class:`CountResult` (or
+    ``None`` on error/offline), while :meth:`start`/:meth:`stop` run it on an
+    interval with exponential-ish back-off.
+    """
+
+    def __init__(
+        self,
+        config: TrayConfig,
+        on_count: Callable[[CountResult], None],
+        notifier: Optional[object] = None,
+        on_break_clicked: Optional[Callable[[], None]] = None,
+        token_provider: Optional[Callable[[], Optional[str]]] = None,
+        set_offline: Optional[Callable[[bool], None]] = None,
+    ):
+        """Initialize the poller.
+
+        Args:
+            config: Tray configuration (hosted_url, lane, poll interval).
+            on_count: Called with each successful :class:`CountResult` (used to
+                drive the tray badge / state).
+            notifier: Optional object with a ``show(title, body, on_clicked=…)``
+                method (a :class:`NotificationManager`).
+            on_break_clicked: Optional lane-aware click handler for the
+                notification. Defaults to :func:`route_break_click` behaviour.
+            token_provider: Returns the current bearer token. Defaults to
+                ``config.get_ingest_token``.
+            set_offline: Optional callback invoked with the offline boolean each
+                cycle (used to drive the tray sync channel).
+        """
+        self.config = config
+        self._on_count = on_count
+        self._notifier = notifier
+        self._on_break_clicked = on_break_clicked
+        self._token_provider = token_provider or config.get_ingest_token
+        self._set_offline = set_offline
+
+        self._last_count = 0
+        self._current_interval = config.effective_poll_interval_s()
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+
+    # --- single-shot request ------------------------------------------------
+
+    def poll_once(self) -> Optional[CountResult]:
+        """Perform one authenticated count request.
+
+        Returns:
+            A :class:`CountResult` on success, or ``None`` if unauthenticated,
+            offline, or the server errored.
+        """
+        token = self._token_provider()
+        if not token:
+            # Not logged in yet — treat as offline for badge purposes.
+            return None
+
+        url = count_url(self.config.hosted_url)
+        headers = {"Authorization": f"Bearer {token}"}
+        try:
+            with httpx.Client(timeout=REQUEST_TIMEOUT_S) as client:
+                resp = client.get(url, headers=headers)
+            if resp.status_code != 200:
+                print(f"needs-attention count returned {resp.status_code}")
+                return None
+            return CountResult.from_payload(resp.json())
+        except Exception as e:
+            # Network error / DNS / timeout / bad JSON → offline.
+            print(f"needs-attention poll failed: {e}")
+            return None
+
+    # --- badge + notification -----------------------------------------------
+
+    def _handle_result(self, result: Optional[CountResult]) -> None:
+        """Apply a poll result: update badge, notify on increase, set interval."""
+        if result is None:
+            # Offline / unauthenticated → back off, mark offline.
+            self._current_interval = OFFLINE_POLL_INTERVAL_S
+            if self._set_offline:
+                self._set_offline(True)
+            return
+
+        # Online: restore configured interval (respecting the floor).
+        self._current_interval = max(
+            MIN_POLL_INTERVAL_S, self.config.effective_poll_interval_s()
+        )
+        if self._set_offline:
+            self._set_offline(False)
+
+        # Drive the badge/state.
+        self._on_count(result)
+
+        # Notify only when the count RISES (0→N or N→N+1), never on a decrease.
+        if result.count > self._last_count and result.count > 0:
+            self._fire_notification(result.count)
+
+        self._last_count = result.count
+
+    def _fire_notification(self, count: int) -> None:
+        """Fire the 'N automations need attention' notification."""
+        if not self._notifier:
+            return
+        noun = "automation" if count == 1 else "automations"
+        try:
+            self._notifier.show(
+                "Automations need attention",
+                f"{count} {noun} need attention",
+                urgency="critical",
+                on_clicked=self._on_break_clicked or self._default_click,
+            )
+        except Exception as e:
+            print(f"Failed to show needs-attention notification: {e}")
+
+    def _default_click(self) -> None:
+        """Fallback click handler (cloud-lane browser open)."""
+        route_break_click(self.config, ipc_client=None)
+
+    # --- loop ---------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the background poll loop."""
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+        self._thread.start()
+
+    def _loop(self) -> None:
+        """Poll on an interval until stopped."""
+        while not self._stop.is_set():
+            result = self.poll_once()
+            self._handle_result(result)
+            # Wait for the (possibly backed-off) interval, or until stopped.
+            self._stop.wait(self._current_interval)
+
+    def stop(self) -> None:
+        """Stop the background poll loop."""
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=2.0)
+            self._thread = None
+
+    @property
+    def current_interval(self) -> int:
+        """The interval (seconds) the loop will wait after the last cycle."""
+        return self._current_interval
+
+
+def route_break_click(
+    config: TrayConfig,
+    ipc_client: Optional[object] = None,
+) -> None:
+    """Route a break/needs-attention click by deployment lane.
+
+    Args:
+        config: Tray configuration (provides lane + hosted_url).
+        ipc_client: Optional IPC client used for the byoc local-teach route.
+    """
+    if config.deployment_lane == "byoc":
+        # PHI stays local: open the desktop teach view over IPC.
+        if ipc_client is not None:
+            try:
+                ipc_client.send_open_teach()
+                return
+            except Exception as e:
+                print(f"Failed to route byoc break click to desktop: {e}")
+        # Fall through to the dashboard if the desktop is unreachable.
+    webbrowser.open(f"{config.hosted_url.rstrip('/')}/dashboard/needs-attention")

--- a/src/openadapt_tray/icons.py
+++ b/src/openadapt_tray/icons.py
@@ -18,8 +18,7 @@ class IconManager:
         TrayState.RECORDING_STARTING: "recording.png",
         TrayState.RECORDING: "recording.png",
         TrayState.RECORDING_STOPPING: "recording.png",
-        TrayState.TRAINING: "training.png",
-        TrayState.TRAINING_PAUSED: "training.png",
+        TrayState.COMPILING: "compiling.png",
         TrayState.ERROR: "error.png",
     }
 
@@ -29,10 +28,12 @@ class IconManager:
         TrayState.RECORDING_STARTING: "#F5A623",  # Yellow/Orange
         TrayState.RECORDING: "#D0021B",  # Red
         TrayState.RECORDING_STOPPING: "#F5A623",  # Yellow/Orange
-        TrayState.TRAINING: "#7B68EE",  # Purple
-        TrayState.TRAINING_PAUSED: "#9B59B6",  # Lighter Purple
+        TrayState.COMPILING: "#7B68EE",  # Purple (transforming a recording)
         TrayState.ERROR: "#D0021B",  # Red
     }
+
+    # Colour of the break/needs-attention badge dot.
+    BADGE_COLOR = "#D0021B"  # Red
 
     def __init__(self, assets_dir: Optional[Path] = None):
         """Initialize the icon manager.
@@ -56,19 +57,23 @@ class IconManager:
             return 2
         return 1
 
-    def get(self, state: TrayState) -> Image.Image:
-        """Get the icon for a given state.
+    def get(self, state: TrayState, break_count: int = 0) -> Image.Image:
+        """Get the icon for a given state, optionally with a break badge.
 
         Args:
-            state: The application state.
+            state: The recording-lifecycle state.
+            break_count: Number of automations needing attention. When > 0 a
+                small red badge dot is overlaid on the icon.
 
         Returns:
             PIL Image for the icon.
         """
         icon_name = self.STATE_ICONS.get(state, "idle.png")
 
-        # Check cache first
-        cache_key = f"{icon_name}_{self._retina_scale}"
+        # Badge presence is part of the cache key so badged/unbadged variants
+        # don't collide.
+        badge = break_count > 0
+        cache_key = f"{icon_name}_{self._retina_scale}_badge={badge}"
         if cache_key in self._cache:
             return self._cache[cache_key]
 
@@ -78,8 +83,39 @@ class IconManager:
             # Generate fallback icon
             icon = self._generate_fallback(state)
 
+        if badge:
+            icon = self._apply_badge(icon)
+
         self._cache[cache_key] = icon
         return icon
+
+    def _apply_badge(self, icon: Image.Image) -> Image.Image:
+        """Overlay a small badge dot on the top-right of an icon.
+
+        Args:
+            icon: The base icon image.
+
+        Returns:
+            A new image with the badge composited on top.
+        """
+        from PIL import ImageDraw
+
+        base = icon.convert("RGBA").copy()
+        w, h = base.size
+        draw = ImageDraw.Draw(base)
+
+        # Badge sized relative to the icon, anchored top-right.
+        radius = max(4, w // 4)
+        cx, cy = w - radius, radius
+        color = self.BADGE_COLOR.lstrip("#")
+        r = int(color[0:2], 16)
+        g = int(color[2:4], 16)
+        b = int(color[4:6], 16)
+        draw.ellipse(
+            [cx - radius, cy - radius, cx + radius, cy + radius],
+            fill=(r, g, b, 255),
+        )
+        return base
 
     def _load_icon(self, icon_name: str) -> Optional[Image.Image]:
         """Try to load an icon from the assets directory.

--- a/src/openadapt_tray/ipc.py
+++ b/src/openadapt_tray/ipc.py
@@ -1,44 +1,73 @@
-"""Inter-process communication for OpenAdapt Tray."""
+"""Inter-process communication for OpenAdapt Tray.
+
+The tray is an IPC *client* that connects to a loopback TCP socket server
+exposed by the desktop app. The desktop writes its bound host/port and a
+per-session shared token to a discovery file at ``~/.openadapt/desktop_ipc.json``;
+the tray reads it, connects, and includes the token on every command so the
+desktop can reject other local processes.
+
+Transport is newline-delimited JSON. Commands flow tray→desktop; events flow
+desktop→tray. The desktop app is the source of truth for all state — the tray
+only renders it.
+"""
 
 import json
 import socket
 import threading
+from pathlib import Path
 from typing import Optional, Callable, Dict, Any
 from dataclasses import dataclass
 from enum import Enum
 
 
-class IPCMessageType(Enum):
-    """IPC message types."""
+# Discovery file the desktop app writes on startup (see §3d of the spec).
+DEFAULT_DISCOVERY_PATH = Path.home() / ".openadapt" / "desktop_ipc.json"
 
-    # Commands (from tray to capture process)
+
+class IPCMessageType(Enum):
+    """IPC message types exchanged with the desktop app."""
+
+    # Commands (tray → desktop)
     START_RECORDING = "start_recording"
     STOP_RECORDING = "stop_recording"
     GET_STATUS = "get_status"
+    OPEN_WORKFLOW_LIBRARY = "open_workflow_library"
+    OPEN_TEACH = "open_teach"
+    PAUSE_SYNC = "pause_sync"
+    RESUME_SYNC = "resume_sync"
 
-    # Events (from capture process to tray)
+    # Events (desktop → tray)
     RECORDING_STARTED = "recording_started"
     RECORDING_STOPPED = "recording_stopped"
     RECORDING_ERROR = "recording_error"
     STATUS_UPDATE = "status_update"
-    TRAINING_PROGRESS = "training_progress"
+    COMPILE_PROGRESS = "compile_progress"
+    SYNC_STATE = "sync_state"
+    BREAK_COUNT = "break_count"
 
 
 @dataclass
 class IPCMessage:
-    """IPC message structure."""
+    """IPC message structure (newline-delimited JSON on the wire).
+
+    Command messages (tray → desktop) carry the per-session ``token`` from the
+    discovery file so the desktop can authenticate the sender. Event messages
+    (desktop → tray) carry a ``data`` payload.
+    """
 
     type: IPCMessageType
     data: Optional[Dict[str, Any]] = None
+    token: Optional[str] = None
 
     def to_json(self) -> str:
         """Serialize to JSON string."""
-        return json.dumps(
-            {
-                "type": self.type.value,
-                "data": self.data,
-            }
-        )
+        obj: Dict[str, Any] = {
+            "type": self.type.value,
+            "data": self.data,
+        }
+        if self.token is not None:
+            obj["token"] = self.token
+        return json.dumps(obj)
 
     @classmethod
     def from_json(cls, json_str: str) -> "IPCMessage":
@@ -47,7 +76,48 @@ class IPCMessage:
         return cls(
             type=IPCMessageType(obj["type"]),
             data=obj.get("data"),
+            token=obj.get("token"),
         )
+
+
+@dataclass
+class DesktopEndpoint:
+    """Discovered desktop-app IPC endpoint."""
+
+    host: str
+    port: int
+    token: Optional[str] = None
+
+    @classmethod
+    def load(
+        cls, path: Optional[Path] = None
+    ) -> Optional["DesktopEndpoint"]:
+        """Load the desktop IPC endpoint from the discovery file.
+
+        Args:
+            path: Discovery file path. Defaults to
+                ``~/.openadapt/desktop_ipc.json``.
+
+        Returns:
+            A :class:`DesktopEndpoint` if the file exists and is valid,
+            otherwise ``None`` (desktop app not running).
+        """
+        path = path or DEFAULT_DISCOVERY_PATH
+        try:
+            if not path.exists():
+                return None
+            data = json.loads(path.read_text())
+            port = data.get("port")
+            if port is None:
+                return None
+            return cls(
+                host=data.get("host", "127.0.0.1"),
+                port=int(port),
+                token=data.get("token"),
+            )
+        except (OSError, ValueError, json.JSONDecodeError) as e:
+            print(f"Could not read desktop IPC discovery file: {e}")
+            return None
 
 
 class IPCClient:
@@ -60,19 +130,62 @@ class IPCClient:
         self,
         host: str = DEFAULT_HOST,
         port: int = DEFAULT_PORT,
+        token: Optional[str] = None,
     ):
         """Initialize IPC client.
 
         Args:
-            host: Host address for IPC server.
-            port: Port number for IPC server.
+            host: Host address for the desktop IPC server.
+            port: Port number for the desktop IPC server.
+            token: Per-session shared token (from the discovery file) attached
+                to every command so the desktop can authenticate the sender.
         """
         self.host = host
         self.port = port
+        self.token = token
         self._socket: Optional[socket.socket] = None
         self._listener_thread: Optional[threading.Thread] = None
         self._running = False
         self._handlers: Dict[IPCMessageType, Callable[[IPCMessage], None]] = {}
+
+    @classmethod
+    def from_discovery(
+        cls, path: Optional[Path] = None
+    ) -> Optional["IPCClient"]:
+        """Build a client from the desktop discovery file, if present.
+
+        Args:
+            path: Discovery file path. Defaults to
+                ``~/.openadapt/desktop_ipc.json``.
+
+        Returns:
+            A configured :class:`IPCClient`, or ``None`` if the desktop app is
+            not running (no discovery file).
+        """
+        endpoint = DesktopEndpoint.load(path)
+        if endpoint is None:
+            return None
+        return cls(host=endpoint.host, port=endpoint.port, token=endpoint.token)
+
+    def refresh_from_discovery(self, path: Optional[Path] = None) -> bool:
+        """Re-read the discovery file and update host/port/token in place.
+
+        Useful after launching the desktop app: the discovery file appears once
+        the desktop's socket server is bound.
+
+        Args:
+            path: Discovery file path. Defaults to the standard location.
+
+        Returns:
+            True if a valid endpoint was found and applied.
+        """
+        endpoint = DesktopEndpoint.load(path)
+        if endpoint is None:
+            return False
+        self.host = endpoint.host
+        self.port = endpoint.port
+        self.token = endpoint.token
+        return True
 
     def register_handler(
         self,
@@ -155,7 +268,10 @@ class IPCClient:
             print(f"Error handling IPC message: {e}")
 
     def send(self, message: IPCMessage) -> bool:
-        """Send a message to the IPC server.
+        """Send a message to the desktop IPC server.
+
+        The per-session token is attached automatically if not already set on
+        the message.
 
         Args:
             message: Message to send.
@@ -166,6 +282,9 @@ class IPCClient:
         if not self._socket:
             return False
 
+        if message.token is None and self.token is not None:
+            message.token = self.token
+
         try:
             data = message.to_json() + "\n"
             self._socket.sendall(data.encode("utf-8"))
@@ -173,6 +292,22 @@ class IPCClient:
         except (socket.error, OSError) as e:
             print(f"IPC send error: {e}")
             return False
+
+    def send_command(
+        self,
+        message_type: IPCMessageType,
+        data: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Send a parameterless-or-simple command to the desktop.
+
+        Args:
+            message_type: The command type.
+            data: Optional payload.
+
+        Returns:
+            True if sent successfully.
+        """
+        return self.send(IPCMessage(type=message_type, data=data))
 
     def send_start_recording(self, name: str) -> bool:
         """Send start recording command.
@@ -191,20 +326,33 @@ class IPCClient:
         )
 
     def send_stop_recording(self) -> bool:
-        """Send stop recording command.
-
-        Returns:
-            True if sent successfully.
-        """
+        """Send stop recording command."""
         return self.send(IPCMessage(type=IPCMessageType.STOP_RECORDING))
 
     def send_get_status(self) -> bool:
-        """Send status request.
-
-        Returns:
-            True if sent successfully.
-        """
+        """Send status request."""
         return self.send(IPCMessage(type=IPCMessageType.GET_STATUS))
+
+    def send_open_workflow_library(self) -> bool:
+        """Ask the desktop to open its local workflow library window."""
+        return self.send(IPCMessage(type=IPCMessageType.OPEN_WORKFLOW_LIBRARY))
+
+    def send_open_teach(self, workflow_id: Optional[str] = None) -> bool:
+        """Ask the desktop to open the local teach-the-fix view.
+
+        Args:
+            workflow_id: Optional workflow to open teach for.
+        """
+        data = {"workflow_id": workflow_id} if workflow_id else None
+        return self.send(IPCMessage(type=IPCMessageType.OPEN_TEACH, data=data))
+
+    def send_pause_sync(self) -> bool:
+        """Ask the desktop to pause the upload/sync queue."""
+        return self.send(IPCMessage(type=IPCMessageType.PAUSE_SYNC))
+
+    def send_resume_sync(self) -> bool:
+        """Ask the desktop to resume the upload/sync queue."""
+        return self.send(IPCMessage(type=IPCMessageType.RESUME_SYNC))
 
     def is_connected(self) -> bool:
         """Check if connected to IPC server."""

--- a/src/openadapt_tray/keychain.py
+++ b/src/openadapt_tray/keychain.py
@@ -1,0 +1,97 @@
+"""OS keychain access for the hosted ingest token.
+
+Secrets are NEVER written to ``tray.json`` / ``config.toml``. The ingest token
+lives in the OS secure store (macOS Keychain / Windows Credential Manager /
+Linux Secret Service) via ``keyring``, under the SAME service name the desktop
+app's ``engine/auth/store.py`` uses so both surfaces share one credential.
+
+Resolution precedence for reads (mirrors the desktop ``push`` tool):
+    ``OPENADAPT_INGEST_TOKEN`` env var → keychain entry for the host.
+"""
+
+import os
+from typing import Optional
+
+# Shared with the desktop app (spec §3a/§3e): service "ai.openadapt.desktop",
+# account keyed by hosted host.
+KEYCHAIN_SERVICE = "ai.openadapt.desktop"
+ENV_INGEST_TOKEN = "OPENADAPT_INGEST_TOKEN"
+
+try:
+    import keyring
+
+    KEYRING_AVAILABLE = True
+except Exception:  # pragma: no cover - keyring backend may be unavailable
+    keyring = None  # type: ignore[assignment]
+    KEYRING_AVAILABLE = False
+
+
+def _account(host: str) -> str:
+    """Normalize a hosted host into a keychain account key."""
+    return (host or "").rstrip("/")
+
+
+def get_ingest_token(host: str) -> Optional[str]:
+    """Resolve the ingest token for a hosted host.
+
+    Args:
+        host: The hosted base URL (e.g. ``https://app.openadapt.ai``).
+
+    Returns:
+        The bearer token, or ``None`` if unset.
+    """
+    env = os.environ.get(ENV_INGEST_TOKEN)
+    if env:
+        return env
+
+    if not KEYRING_AVAILABLE:
+        return None
+    try:
+        return keyring.get_password(KEYCHAIN_SERVICE, _account(host))
+    except Exception as e:  # pragma: no cover - backend errors
+        print(f"Keychain read failed: {e}")
+        return None
+
+
+def set_ingest_token(host: str, token: str) -> bool:
+    """Store the ingest token for a hosted host in the OS keychain.
+
+    Args:
+        host: The hosted base URL.
+        token: The bearer token to store.
+
+    Returns:
+        True if stored successfully.
+    """
+    if not KEYRING_AVAILABLE:
+        return False
+    try:
+        keyring.set_password(KEYCHAIN_SERVICE, _account(host), token)
+        return True
+    except Exception as e:  # pragma: no cover - backend errors
+        print(f"Keychain write failed: {e}")
+        return False
+
+
+def clear_ingest_token(host: str) -> bool:
+    """Remove the stored ingest token for a hosted host.
+
+    Args:
+        host: The hosted base URL.
+
+    Returns:
+        True if removed (or already absent).
+    """
+    if not KEYRING_AVAILABLE:
+        return False
+    try:
+        keyring.delete_password(KEYCHAIN_SERVICE, _account(host))
+        return True
+    except Exception:
+        # keyring raises if the entry is absent; treat as a no-op success.
+        return False
+
+
+def has_ingest_token(host: str) -> bool:
+    """Return True if an ingest token is resolvable for the host."""
+    return get_ingest_token(host) is not None

--- a/src/openadapt_tray/menu.py
+++ b/src/openadapt_tray/menu.py
@@ -4,12 +4,9 @@ from typing import TYPE_CHECKING, Optional, List
 from functools import partial
 from dataclasses import dataclass
 from datetime import datetime
-from pathlib import Path
 import subprocess
 import shutil
-import webbrowser
 
-import pystray
 from pystray import MenuItem as Item, Menu
 
 if TYPE_CHECKING:
@@ -50,15 +47,56 @@ class MenuBuilder:
             self._build_recording_item(state),
             Menu.SEPARATOR,
             self._build_captures_submenu(),
-            self._build_training_item(state),
+        ]
+
+        # Break/needs-attention entry (only when there are open breaks).
+        break_item = self._build_break_item(state)
+        if break_item is not None:
+            items.append(break_item)
+
+        items += [
             Menu.SEPARATOR,
-            Item("Open Dashboard", self._open_dashboard),
+            Item("Open Desktop App", self._open_desktop_app),
+            Item("Open Cloud Dashboard", self._open_cloud_dashboard),
+            self._build_sync_item(state),
+            Item("Login...", self._login),
             Item("Settings...", self._open_settings),
             Menu.SEPARATOR,
             Item("Quit", self._quit),
         ]
 
         return Menu(*items)
+
+    def _build_break_item(self, state) -> Optional[Item]:
+        """Build the needs-attention entry when breaks are present.
+
+        Args:
+            state: Current application state.
+
+        Returns:
+            A menu item, or ``None`` when there are no open breaks.
+        """
+        if not state.has_breaks():
+            return None
+        count = state.break_count
+        noun = "automation" if count == 1 else "automations"
+        return Item(
+            f"⚠ {count} {noun} need attention",
+            lambda: self.app.open_needs_attention(),
+        )
+
+    def _build_sync_item(self, state) -> Item:
+        """Build the pause/resume-sync toggle.
+
+        Args:
+            state: Current application state.
+
+        Returns:
+            Menu item toggling the upload/sync queue.
+        """
+        if state.is_offline():
+            return Item("Sync (offline)", None, enabled=False)
+        return Item("Pause Sync", lambda: self.app.pause_sync())
 
     def _build_recording_item(self, state) -> Item:
         """Build record/stop recording menu item.
@@ -76,6 +114,8 @@ class MenuBuilder:
             return Item("Starting...", None, enabled=False)
         elif state.state == TrayState.RECORDING_STOPPING:
             return Item("Stopping...", None, enabled=False)
+        elif state.state == TrayState.COMPILING:
+            return Item("Compiling...", None, enabled=False)
         else:
             hotkey = self.app.config.hotkeys.toggle_recording
             label = f"Start Recording ({hotkey})"
@@ -116,33 +156,6 @@ class MenuBuilder:
 
         return Item("Recent Captures", Menu(*capture_items))
 
-    def _build_training_item(self, state) -> Item:
-        """Build training status/control item.
-
-        Args:
-            state: Current application state.
-
-        Returns:
-            Menu item for training control.
-        """
-        if state.state == TrayState.TRAINING:
-            progress = state.training_progress or 0
-            return Item(
-                f"Training: {progress:.0%}",
-                Menu(
-                    Item("View Progress", self._open_training_dashboard),
-                    Item("Stop Training", self._stop_training),
-                ),
-            )
-        else:
-            return Item(
-                "Training",
-                Menu(
-                    Item("Start Training...", self._start_training),
-                    Item("View Last Results", self._view_training_results),
-                ),
-            )
-
     def _get_recent_captures(self) -> List[CaptureInfo]:
         """Get list of recent captures.
 
@@ -177,9 +190,17 @@ class MenuBuilder:
             print(f"Error getting captures: {e}")
             return []
 
-    def _open_dashboard(self) -> None:
-        """Open the web dashboard."""
-        self.app._open_dashboard()
+    def _open_desktop_app(self) -> None:
+        """Open (or focus) the local desktop app cockpit."""
+        self.app.open_desktop_app()
+
+    def _open_cloud_dashboard(self) -> None:
+        """Open the hosted cloud dashboard in the browser."""
+        self.app.open_cloud_dashboard()
+
+    def _login(self) -> None:
+        """Start the hosted login flow."""
+        self.app.login()
 
     def _open_settings(self) -> None:
         """Open settings dialog."""
@@ -232,55 +253,8 @@ class MenuBuilder:
                 )
 
     def _open_captures_list(self) -> None:
-        """Open captures list in dashboard."""
-        webbrowser.open(f"http://localhost:{self.app.config.dashboard_port}/captures")
-
-    def _open_training_dashboard(self) -> None:
-        """Open training dashboard."""
-        webbrowser.open(f"http://localhost:{self.app.config.dashboard_port}/training")
-
-    def _start_training(self) -> None:
-        """Open training configuration dialog."""
-        self.app.platform.open_training_dialog()
-
-    def _stop_training(self) -> None:
-        """Stop current training."""
-        try:
-            subprocess.run(
-                ["openadapt", "train", "stop"],
-                capture_output=True,
-                timeout=10,
-            )
-            self.app.state.transition(TrayState.IDLE)
-        except Exception as e:
-            print(f"Error stopping training: {e}")
-
-    def _view_training_results(self) -> None:
-        """View last training results."""
-        try:
-            result = subprocess.run(
-                ["openadapt", "train", "status"],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-            if result.returncode == 0 and result.stdout:
-                self.app.notifications.show(
-                    "Training Status",
-                    result.stdout.strip()[:200],  # Limit notification length
-                )
-            else:
-                self.app.notifications.show(
-                    "Training Status",
-                    "No training results available.",
-                )
-        except FileNotFoundError:
-            self.app.notifications.show(
-                "Training Status",
-                "openadapt CLI not found.",
-            )
-        except Exception as e:
-            print(f"Error getting training status: {e}")
+        """Open the local workflow library in the desktop app."""
+        self.app.open_desktop_app()
 
     def _open_in_file_browser(self, path: str) -> None:
         """Open a path in the system file browser.

--- a/src/openadapt_tray/notifications.py
+++ b/src/openadapt_tray/notifications.py
@@ -80,7 +80,7 @@ class NotificationManager:
                 try:
                     from desktop_notifier.macos import CocoaNotificationCenter
                     # Try to initialize to see if it works
-                    test_notifier = CocoaNotificationCenter()
+                    CocoaNotificationCenter()
                     print("desktop-notifier initialized successfully")
                     return "desktop-notifier"
                 except Exception as e:

--- a/src/openadapt_tray/notifications.py
+++ b/src/openadapt_tray/notifications.py
@@ -45,7 +45,7 @@ class NotificationManager:
             )
             # Create event loop for async operations
             try:
-                self._loop = asyncio.get_event_loop()
+                self._loop = asyncio.get_running_loop()
             except RuntimeError:
                 self._loop = asyncio.new_event_loop()
                 asyncio.set_event_loop(self._loop)

--- a/src/openadapt_tray/platform/macos.py
+++ b/src/openadapt_tray/platform/macos.py
@@ -116,8 +116,6 @@ class MacOSHandler(PlatformHandler):
         Returns:
             True if successful.
         """
-        import sys
-
         plist_path = Path.home() / "Library/LaunchAgents/ai.openadapt.tray.plist"
 
         try:

--- a/src/openadapt_tray/platform/windows.py
+++ b/src/openadapt_tray/platform/windows.py
@@ -101,7 +101,6 @@ class WindowsHandler(PlatformHandler):
         """
         try:
             import winreg
-            import sys
 
             key_path = r"Software\Microsoft\Windows\CurrentVersion\Run"
             app_name = "OpenAdapt"

--- a/src/openadapt_tray/state.py
+++ b/src/openadapt_tray/state.py
@@ -1,30 +1,70 @@
-"""Application state management for OpenAdapt Tray."""
+"""Application state management for OpenAdapt Tray.
+
+The tray mirrors two ORTHOGONAL status channels sourced from the local desktop
+app and the cloud control plane:
+
+* ``TrayState`` — the recording/compile lifecycle (idle → recording → compiling).
+* ``SyncState`` — the upload/sync channel (synced ↔ syncing ↔ offline).
+
+They are independent: a machine can be ``COMPILING`` a freshly recorded
+workflow while its previous push is still ``SYNCING``, or sit ``IDLE`` while
+``OFFLINE``. Modelling them as one enum would force false exclusivity, so
+``AppState`` carries them as two separate fields plus a ``break_count`` badge
+sourced from the cloud needs-attention count.
+"""
 
 from enum import Enum, auto
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional, Callable, List
 
 
 class TrayState(Enum):
-    """Application states."""
+    """Recording / compile lifecycle states (the primary icon channel)."""
 
     IDLE = auto()
     RECORDING_STARTING = auto()
     RECORDING = auto()
     RECORDING_STOPPING = auto()
-    TRAINING = auto()
-    TRAINING_PAUSED = auto()
+    COMPILING = auto()
     ERROR = auto()
+
+
+class SyncState(Enum):
+    """Upload / sync channel states (orthogonal to :class:`TrayState`)."""
+
+    SYNCED = auto()
+    SYNCING = auto()  # a.k.a. PUSHING — an upload is in flight
+    OFFLINE = auto()
+
+    # Backwards/spec-friendly alias: the spec names this channel "SYNCING/PUSHING".
+    @classmethod
+    def PUSHING(cls) -> "SyncState":  # noqa: N802 - alias helper
+        """Alias for :attr:`SYNCING` (the spec uses SYNCING/PUSHING interchangeably)."""
+        return cls.SYNCING
+
+
+# Deployment lanes (drives break-click routing; learned from desktop/config).
+LANE_CLOUD = "cloud"
+LANE_BYOC = "byoc"
 
 
 @dataclass
 class AppState:
-    """Current application state."""
+    """Current application state (two orthogonal channels + a break badge)."""
 
+    # Recording / compile lifecycle.
     state: TrayState = TrayState.IDLE
     current_capture: Optional[str] = None
-    training_progress: Optional[float] = None
     error_message: Optional[str] = None
+
+    # Sync channel (independent of the recording lifecycle).
+    sync_state: SyncState = SyncState.SYNCED
+
+    # Break / needs-attention badge (sourced from the cloud count endpoint).
+    break_count: int = 0
+
+    # Deployment lane — drives lane-aware break-click routing.
+    deployment_lane: str = LANE_CLOUD
 
     def can_start_recording(self) -> bool:
         """Check if recording can be started."""
@@ -42,17 +82,38 @@ class AppState:
             TrayState.RECORDING_STOPPING,
         )
 
-    def is_training(self) -> bool:
-        """Check if currently training."""
-        return self.state in (TrayState.TRAINING, TrayState.TRAINING_PAUSED)
+    def is_compiling(self) -> bool:
+        """Check if a recording is being compiled into a workflow."""
+        return self.state == TrayState.COMPILING
 
     def is_busy(self) -> bool:
-        """Check if the application is busy with any operation."""
+        """Check if the application is busy with any recording operation."""
         return self.state not in (TrayState.IDLE, TrayState.ERROR)
+
+    def is_syncing(self) -> bool:
+        """Check if an upload is currently in flight."""
+        return self.sync_state == SyncState.SYNCING
+
+    def is_offline(self) -> bool:
+        """Check if the sync channel is offline."""
+        return self.sync_state == SyncState.OFFLINE
+
+    def has_breaks(self) -> bool:
+        """Check if any automations currently need attention."""
+        return self.break_count > 0
+
+    def is_byoc(self) -> bool:
+        """Check if the active deployment lane keeps PHI on-machine (byoc)."""
+        return self.deployment_lane == LANE_BYOC
 
 
 class StateManager:
-    """Manages application state transitions."""
+    """Manages application state transitions across both channels.
+
+    Recording-lifecycle updates (:meth:`transition`) preserve the orthogonal
+    sync channel, break count and deployment lane unless explicitly overridden,
+    and vice-versa — so updating one channel never clobbers the other.
+    """
 
     def __init__(self):
         self._state = AppState()
@@ -67,28 +128,70 @@ class StateManager:
         if callback in self._listeners:
             self._listeners.remove(callback)
 
-    def transition(self, new_state: TrayState, **kwargs) -> None:
-        """Transition to a new state and notify listeners.
-
-        Args:
-            new_state: The new state to transition to.
-            **kwargs: Additional state attributes (current_capture, training_progress, error_message).
-        """
-        # Preserve certain fields if not explicitly set
-        if "current_capture" not in kwargs and new_state in (
-            TrayState.RECORDING,
-            TrayState.RECORDING_STOPPING,
-        ):
-            kwargs.setdefault("current_capture", self._state.current_capture)
-
-        self._state = AppState(state=new_state, **kwargs)
-
+    def _emit(self) -> None:
+        """Notify all listeners of the current state."""
         for listener in self._listeners:
             try:
                 listener(self._state)
             except Exception as e:
-                # Don't let a bad listener crash the app
+                # Don't let a bad listener crash the app.
                 print(f"Error in state listener: {e}")
+
+    def transition(self, new_state: TrayState, **kwargs) -> None:
+        """Transition the recording lifecycle and notify listeners.
+
+        The orthogonal channels (``sync_state``, ``break_count``,
+        ``deployment_lane``) are preserved from the current state unless passed
+        explicitly in ``kwargs``.
+
+        Args:
+            new_state: The new recording-lifecycle state.
+            **kwargs: Optional overrides (``current_capture``, ``error_message``,
+                ``sync_state``, ``break_count``, ``deployment_lane``).
+        """
+        # Preserve current_capture across sub-states of an active recording.
+        if "current_capture" not in kwargs and new_state in (
+            TrayState.RECORDING,
+            TrayState.RECORDING_STOPPING,
+            TrayState.COMPILING,
+        ):
+            kwargs.setdefault("current_capture", self._state.current_capture)
+
+        # Preserve the orthogonal channels unless explicitly overridden.
+        kwargs.setdefault("sync_state", self._state.sync_state)
+        kwargs.setdefault("break_count", self._state.break_count)
+        kwargs.setdefault("deployment_lane", self._state.deployment_lane)
+
+        self._state = AppState(state=new_state, **kwargs)
+        self._emit()
+
+    def set_sync_state(self, sync_state: SyncState) -> None:
+        """Update ONLY the sync channel, preserving the recording lifecycle."""
+        if self._state.sync_state == sync_state:
+            return
+        from dataclasses import replace
+
+        self._state = replace(self._state, sync_state=sync_state)
+        self._emit()
+
+    def set_break_count(self, count: int) -> None:
+        """Update ONLY the break/needs-attention badge count."""
+        count = max(0, int(count))
+        if self._state.break_count == count:
+            return
+        from dataclasses import replace
+
+        self._state = replace(self._state, break_count=count)
+        self._emit()
+
+    def set_deployment_lane(self, lane: str) -> None:
+        """Update ONLY the deployment lane (cloud|byoc)."""
+        if self._state.deployment_lane == lane:
+            return
+        from dataclasses import replace
+
+        self._state = replace(self._state, deployment_lane=lane)
+        self._emit()
 
     @property
     def current(self) -> AppState:
@@ -96,5 +199,5 @@ class StateManager:
         return self._state
 
     def reset(self) -> None:
-        """Reset to initial state."""
+        """Reset the recording lifecycle to IDLE (sync channel preserved)."""
         self.transition(TrayState.IDLE)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,6 @@
 """Tests for the main TrayApplication."""
 
-import pytest
-from unittest.mock import patch, MagicMock, PropertyMock
+from unittest.mock import patch, MagicMock
 
 from openadapt_tray.state import TrayState
 from openadapt_tray.config import TrayConfig
@@ -57,8 +56,9 @@ class TestRecordingControls:
 
         app = TrayApplication()
 
-        # Start recording with a name (skip prompt)
-        with patch.object(app, "_run_capture"):
+        # Start recording with a name (skip prompt); the desktop dispatch runs
+        # on a background thread, so stub it out.
+        with patch.object(app, "_dispatch_start_recording"):
             app.start_recording("test_capture")
 
         assert app.state.current.state in (
@@ -78,14 +78,14 @@ class TestRecordingControls:
         app = TrayApplication()
         app.state.transition(TrayState.RECORDING, current_capture="existing")
 
-        with patch.object(app, "_run_capture") as mock_run:
+        with patch.object(app, "_dispatch_start_recording") as mock_dispatch:
             app.start_recording("new_capture")
-            mock_run.assert_not_called()
+            mock_dispatch.assert_not_called()
 
     @patch("openadapt_tray.app.pystray")
     @patch("openadapt_tray.app.get_platform_handler")
-    def test_stop_recording_changes_state(self, mock_platform, mock_pystray):
-        """Test that stop_recording transitions to IDLE."""
+    def test_stop_recording_signals_desktop(self, mock_platform, mock_pystray):
+        """stop_recording transitions to STOPPING and signals the desktop."""
         from openadapt_tray.app import TrayApplication
 
         mock_platform.return_value = MagicMock()
@@ -94,9 +94,12 @@ class TestRecordingControls:
         app = TrayApplication()
         app.state.transition(TrayState.RECORDING, current_capture="test")
 
-        app.stop_recording()
+        with patch.object(app.ipc, "send_stop_recording") as mock_stop:
+            app.stop_recording()
+            mock_stop.assert_called_once()
 
-        assert app.state.current.state == TrayState.IDLE
+        # The tray waits for the desktop's RECORDING_STOPPED event.
+        assert app.state.current.state == TrayState.RECORDING_STOPPING
 
     @patch("openadapt_tray.app.pystray")
     @patch("openadapt_tray.app.get_platform_handler")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,7 @@
 """Tests for configuration management."""
 
-import json
-import pytest
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from openadapt_tray.config import TrayConfig
 from openadapt_tray.shortcuts import HotkeyConfig
@@ -83,14 +81,63 @@ class TestTrayConfig:
         assert not str(path).startswith("~")
         assert str(path).endswith("test/captures")
 
-    def test_get_training_path(self):
-        """Test training path expansion."""
-        config = TrayConfig(training_output_directory="~/test/training")
-        path = config.get_training_path()
+    def test_hosted_defaults(self):
+        """Test hosted/loop config defaults."""
+        config = TrayConfig()
+        assert config.hosted_url == "https://app.openadapt.ai"
+        assert config.deployment_lane == "cloud"
+        assert config.poll_interval_s == 60
+        assert config.desktop_ipc_port is None
 
-        assert isinstance(path, Path)
-        assert not str(path).startswith("~")
-        assert str(path).endswith("test/training")
+    def test_hosted_keys_roundtrip(self):
+        """Hosted keys survive to_dict/_from_dict."""
+        config = TrayConfig(
+            hosted_url="https://example.test",
+            deployment_lane="byoc",
+            poll_interval_s=120,
+            desktop_ipc_port=54321,
+        )
+        data = config.to_dict()
+        assert data["hosted_url"] == "https://example.test"
+        assert data["deployment_lane"] == "byoc"
+        assert data["poll_interval_s"] == 120
+        assert data["desktop_ipc_port"] == 54321
+
+        loaded = TrayConfig._from_dict(data)
+        assert loaded.hosted_url == "https://example.test"
+        assert loaded.deployment_lane == "byoc"
+        assert loaded.poll_interval_s == 120
+        assert loaded.desktop_ipc_port == 54321
+
+    def test_effective_poll_interval_clamps_to_floor(self):
+        """Poll interval never drops below the safe minimum."""
+        assert TrayConfig(poll_interval_s=5).effective_poll_interval_s() == 30
+        assert TrayConfig(poll_interval_s=90).effective_poll_interval_s() == 90
+
+    def test_from_dict_ignores_stale_keys(self):
+        """Unknown/retired keys (e.g. training_output_directory) are dropped."""
+        data = {
+            "dashboard_port": 9000,
+            "training_output_directory": "~/old/training",  # retired
+            "unknown_future_key": 123,
+        }
+        config = TrayConfig._from_dict(data)
+        assert config.dashboard_port == 9000
+        assert not hasattr(config, "training_output_directory")
+
+    def test_get_ingest_token_reads_keychain(self):
+        """Token resolution delegates to the keychain helper (never the file)."""
+        config = TrayConfig(hosted_url="https://example.test")
+        with patch(
+            "openadapt_tray.keychain.get_ingest_token", return_value="oai_ingest_x"
+        ) as mock_get:
+            assert config.get_ingest_token() == "oai_ingest_x"
+            mock_get.assert_called_once_with("https://example.test")
+
+    def test_token_never_in_serialized_config(self):
+        """The serialized config must not contain any token field."""
+        data = TrayConfig().to_dict()
+        assert not any("token" in k for k in data)
 
     def test_save_and_load(self, tmp_path):
         """Test saving and loading configuration."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -79,7 +79,7 @@ class TestTrayConfig:
 
         assert isinstance(path, Path)
         assert not str(path).startswith("~")
-        assert str(path).endswith("test/captures")
+        assert path.parts[-2:] == ("test", "captures")
 
     def test_hosted_defaults(self):
         """Test hosted/loop config defaults."""

--- a/tests/test_hosted.py
+++ b/tests/test_hosted.py
@@ -1,0 +1,243 @@
+"""Tests for the cloud needs-attention poller (mocks httpx)."""
+
+from unittest.mock import MagicMock, patch
+
+
+from openadapt_tray.config import (
+    TrayConfig,
+    OFFLINE_POLL_INTERVAL_S,
+    MIN_POLL_INTERVAL_S,
+)
+from openadapt_tray.hosted import (
+    HostedPoller,
+    CountResult,
+    count_url,
+    route_break_click,
+)
+
+
+def make_config(**kw):
+    """Build a config with a token available via a patched keychain read."""
+    return TrayConfig(hosted_url="https://example.test", **kw)
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    """Context-manager stand-in for httpx.Client."""
+
+    def __init__(self, response=None, raise_exc=None):
+        self._response = response
+        self._raise = raise_exc
+        self.last_url = None
+        self.last_headers = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def get(self, url, headers=None):
+        self.last_url = url
+        self.last_headers = headers
+        if self._raise:
+            raise self._raise
+        return self._response
+
+
+class TestCountResult:
+    def test_from_payload(self):
+        r = CountResult.from_payload(
+            {"count": 3, "open_halts": 2, "failed_runs": 1}
+        )
+        assert (r.count, r.open_halts, r.failed_runs) == (3, 2, 1)
+
+    def test_from_payload_tolerates_missing(self):
+        r = CountResult.from_payload({"count": 5})
+        assert r.count == 5
+        assert r.open_halts == 0
+        assert r.failed_runs == 0
+
+
+class TestCountUrl:
+    def test_count_url(self):
+        assert (
+            count_url("https://example.test/")
+            == "https://example.test/api/needs-attention/count"
+        )
+
+
+class TestPollOnce:
+    """Tests for the single authenticated request."""
+
+    def test_poll_once_success(self):
+        cfg = make_config()
+        poller = HostedPoller(
+            cfg, on_count=lambda r: None, token_provider=lambda: "oai_ingest_x"
+        )
+        fake = _FakeClient(
+            _FakeResponse(200, {"count": 4, "open_halts": 4, "failed_runs": 0})
+        )
+        with patch("openadapt_tray.hosted.httpx.Client", return_value=fake):
+            result = poller.poll_once()
+
+        assert result is not None
+        assert result.count == 4
+        # Verify the exact request contract (endpoint + bearer auth).
+        assert fake.last_url == "https://example.test/api/needs-attention/count"
+        assert fake.last_headers["Authorization"] == "Bearer oai_ingest_x"
+
+    def test_poll_once_no_token_returns_none(self):
+        cfg = make_config()
+        poller = HostedPoller(
+            cfg, on_count=lambda r: None, token_provider=lambda: None
+        )
+        # httpx must not even be called without a token.
+        with patch("openadapt_tray.hosted.httpx.Client") as mock_client:
+            assert poller.poll_once() is None
+            mock_client.assert_not_called()
+
+    def test_poll_once_non_200_returns_none(self):
+        cfg = make_config()
+        poller = HostedPoller(
+            cfg, on_count=lambda r: None, token_provider=lambda: "t"
+        )
+        fake = _FakeClient(_FakeResponse(401, {}))
+        with patch("openadapt_tray.hosted.httpx.Client", return_value=fake):
+            assert poller.poll_once() is None
+
+    def test_poll_once_network_error_returns_none(self):
+        cfg = make_config()
+        poller = HostedPoller(
+            cfg, on_count=lambda r: None, token_provider=lambda: "t"
+        )
+        fake = _FakeClient(raise_exc=OSError("no route to host"))
+        with patch("openadapt_tray.hosted.httpx.Client", return_value=fake):
+            assert poller.poll_once() is None
+
+
+class TestHandleResult:
+    """Tests for badge updates, notifications, and back-off."""
+
+    def test_notifies_on_increase(self):
+        cfg = make_config()
+        counts = []
+        notifier = MagicMock()
+        poller = HostedPoller(
+            cfg,
+            on_count=lambda r: counts.append(r.count),
+            notifier=notifier,
+            token_provider=lambda: "t",
+        )
+
+        poller._handle_result(CountResult(count=2))
+
+        assert counts == [2]
+        notifier.show.assert_called_once()
+        # Body reads "N automations need attention".
+        args, kwargs = notifier.show.call_args
+        assert "2 automations need attention" in args[1]
+
+    def test_no_notify_on_same_count(self):
+        cfg = make_config()
+        notifier = MagicMock()
+        poller = HostedPoller(
+            cfg, on_count=lambda r: None, notifier=notifier,
+            token_provider=lambda: "t",
+        )
+        poller._handle_result(CountResult(count=2))
+        notifier.reset_mock()
+        poller._handle_result(CountResult(count=2))
+        notifier.show.assert_not_called()
+
+    def test_no_notify_on_decrease(self):
+        cfg = make_config()
+        notifier = MagicMock()
+        poller = HostedPoller(
+            cfg, on_count=lambda r: None, notifier=notifier,
+            token_provider=lambda: "t",
+        )
+        poller._handle_result(CountResult(count=3))
+        notifier.reset_mock()
+        poller._handle_result(CountResult(count=1))
+        notifier.show.assert_not_called()
+
+    def test_singular_wording(self):
+        cfg = make_config()
+        notifier = MagicMock()
+        poller = HostedPoller(
+            cfg, on_count=lambda r: None, notifier=notifier,
+            token_provider=lambda: "t",
+        )
+        poller._handle_result(CountResult(count=1))
+        args, _ = notifier.show.call_args
+        assert "1 automation need" in args[1]
+
+    def test_offline_backs_off_and_flags(self):
+        cfg = make_config(poll_interval_s=60)
+        offline_flags = []
+        poller = HostedPoller(
+            cfg,
+            on_count=lambda r: None,
+            token_provider=lambda: "t",
+            set_offline=lambda o: offline_flags.append(o),
+        )
+        poller._handle_result(None)
+        assert poller.current_interval == OFFLINE_POLL_INTERVAL_S
+        assert offline_flags == [True]
+
+    def test_recovers_interval_when_online(self):
+        cfg = make_config(poll_interval_s=45)
+        offline_flags = []
+        poller = HostedPoller(
+            cfg,
+            on_count=lambda r: None,
+            token_provider=lambda: "t",
+            set_offline=lambda o: offline_flags.append(o),
+        )
+        poller._handle_result(None)  # offline → 300s
+        poller._handle_result(CountResult(count=0))  # online → back to 45s
+        assert poller.current_interval == 45
+        assert offline_flags == [True, False]
+
+    def test_interval_never_below_floor(self):
+        cfg = make_config(poll_interval_s=5)  # below the floor
+        poller = HostedPoller(
+            cfg, on_count=lambda r: None, token_provider=lambda: "t"
+        )
+        poller._handle_result(CountResult(count=0))
+        assert poller.current_interval == MIN_POLL_INTERVAL_S
+
+
+class TestRouteBreakClick:
+    """Tests for lane-aware click routing (spec §3c)."""
+
+    def test_cloud_lane_opens_dashboard(self):
+        cfg = make_config(deployment_lane="cloud")
+        with patch("openadapt_tray.hosted.webbrowser.open") as mock_open:
+            route_break_click(cfg, ipc_client=None)
+        mock_open.assert_called_once_with(
+            "https://example.test/dashboard/needs-attention"
+        )
+
+    def test_byoc_lane_routes_to_desktop(self):
+        cfg = make_config(deployment_lane="byoc")
+        ipc = MagicMock()
+        with patch("openadapt_tray.hosted.webbrowser.open") as mock_open:
+            route_break_click(cfg, ipc_client=ipc)
+        ipc.send_open_teach.assert_called_once()
+        mock_open.assert_not_called()
+
+    def test_byoc_falls_back_to_dashboard_when_no_desktop(self):
+        cfg = make_config(deployment_lane="byoc")
+        with patch("openadapt_tray.hosted.webbrowser.open") as mock_open:
+            route_break_click(cfg, ipc_client=None)
+        mock_open.assert_called_once()

--- a/tests/test_hosted.py
+++ b/tests/test_hosted.py
@@ -56,15 +56,15 @@ class _FakeClient:
 class TestCountResult:
     def test_from_payload(self):
         r = CountResult.from_payload(
-            {"count": 3, "open_halts": 2, "failed_runs": 1}
+            {"count": 3, "halts": 2, "uncertain_dispatches": 1}
         )
-        assert (r.count, r.open_halts, r.failed_runs) == (3, 2, 1)
+        assert (r.count, r.halts, r.uncertain_dispatches) == (3, 2, 1)
 
     def test_from_payload_tolerates_missing(self):
         r = CountResult.from_payload({"count": 5})
         assert r.count == 5
-        assert r.open_halts == 0
-        assert r.failed_runs == 0
+        assert r.halts == 0
+        assert r.uncertain_dispatches == 0
 
 
 class TestCountUrl:
@@ -84,13 +84,15 @@ class TestPollOnce:
             cfg, on_count=lambda r: None, token_provider=lambda: "oai_ingest_x"
         )
         fake = _FakeClient(
-            _FakeResponse(200, {"count": 4, "open_halts": 4, "failed_runs": 0})
+            _FakeResponse(200, {"count": 4, "halts": 3, "uncertain_dispatches": 1})
         )
         with patch("openadapt_tray.hosted.httpx.Client", return_value=fake):
             result = poller.poll_once()
 
         assert result is not None
         assert result.count == 4
+        assert result.halts == 3
+        assert result.uncertain_dispatches == 1
         # Verify the exact request contract (endpoint + bearer auth).
         assert fake.last_url == "https://example.test/api/needs-attention/count"
         assert fake.last_headers["Authorization"] == "Bearer oai_ingest_x"
@@ -224,9 +226,7 @@ class TestRouteBreakClick:
         cfg = make_config(deployment_lane="cloud")
         with patch("openadapt_tray.hosted.webbrowser.open") as mock_open:
             route_break_click(cfg, ipc_client=None)
-        mock_open.assert_called_once_with(
-            "https://example.test/dashboard/needs-attention"
-        )
+        mock_open.assert_called_once_with("https://example.test/dashboard")
 
     def test_byoc_lane_routes_to_desktop(self):
         cfg = make_config(deployment_lane="byoc")

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -1,0 +1,180 @@
+"""Tests for the desktop IPC client + discovery."""
+
+import json
+
+
+from openadapt_tray.ipc import (
+    IPCMessage,
+    IPCMessageType,
+    IPCClient,
+    DesktopEndpoint,
+    DEFAULT_DISCOVERY_PATH,
+)
+
+
+class TestIPCMessageTypes:
+    """Tests for the extended IPC message vocabulary (spec §3d)."""
+
+    def test_command_types_present(self):
+        """All tray→desktop command types exist."""
+        for name in [
+            "START_RECORDING",
+            "STOP_RECORDING",
+            "GET_STATUS",
+            "OPEN_WORKFLOW_LIBRARY",
+            "OPEN_TEACH",
+            "PAUSE_SYNC",
+            "RESUME_SYNC",
+        ]:
+            assert hasattr(IPCMessageType, name)
+
+    def test_event_types_present(self):
+        """All desktop→tray event types exist."""
+        for name in [
+            "RECORDING_STARTED",
+            "RECORDING_STOPPED",
+            "RECORDING_ERROR",
+            "STATUS_UPDATE",
+            "COMPILE_PROGRESS",
+            "SYNC_STATE",
+            "BREAK_COUNT",
+        ]:
+            assert hasattr(IPCMessageType, name)
+
+    def test_rl_training_type_removed(self):
+        """The retired RL training-progress type must be gone."""
+        assert not hasattr(IPCMessageType, "TRAINING_PROGRESS")
+
+
+class TestIPCMessageSerialization:
+    """Tests for message (de)serialization including the session token."""
+
+    def test_roundtrip_with_token(self):
+        """A command with a token round-trips through JSON."""
+        msg = IPCMessage(
+            type=IPCMessageType.START_RECORDING,
+            data={"name": "w"},
+            token="sess-123",
+        )
+        restored = IPCMessage.from_json(msg.to_json())
+        assert restored.type == IPCMessageType.START_RECORDING
+        assert restored.data == {"name": "w"}
+        assert restored.token == "sess-123"
+
+    def test_token_omitted_when_absent(self):
+        """No token key is emitted when the message has none."""
+        msg = IPCMessage(type=IPCMessageType.GET_STATUS)
+        assert "token" not in json.loads(msg.to_json())
+
+    def test_new_types_roundtrip(self):
+        """New event types deserialize correctly."""
+        for mt in [
+            IPCMessageType.COMPILE_PROGRESS,
+            IPCMessageType.SYNC_STATE,
+            IPCMessageType.BREAK_COUNT,
+        ]:
+            restored = IPCMessage.from_json(
+                IPCMessage(type=mt, data={"x": 1}).to_json()
+            )
+            assert restored.type == mt
+
+
+class TestDesktopEndpointDiscovery:
+    """Tests for the ~/.openadapt/desktop_ipc.json discovery file."""
+
+    def test_load_missing_returns_none(self, tmp_path):
+        """Missing discovery file → None (desktop not running)."""
+        assert DesktopEndpoint.load(tmp_path / "nope.json") is None
+
+    def test_load_valid(self, tmp_path):
+        """A valid discovery file yields host/port/token."""
+        f = tmp_path / "desktop_ipc.json"
+        f.write_text(
+            json.dumps(
+                {"host": "127.0.0.1", "port": 51234, "token": "sess-abc"}
+            )
+        )
+        ep = DesktopEndpoint.load(f)
+        assert ep is not None
+        assert ep.host == "127.0.0.1"
+        assert ep.port == 51234
+        assert ep.token == "sess-abc"
+
+    def test_load_invalid_json_returns_none(self, tmp_path):
+        """Corrupt discovery file → None, not a crash."""
+        f = tmp_path / "desktop_ipc.json"
+        f.write_text("{ not json")
+        assert DesktopEndpoint.load(f) is None
+
+    def test_load_without_port_returns_none(self, tmp_path):
+        """A discovery file missing the port is unusable."""
+        f = tmp_path / "desktop_ipc.json"
+        f.write_text(json.dumps({"host": "127.0.0.1"}))
+        assert DesktopEndpoint.load(f) is None
+
+    def test_default_discovery_path(self):
+        """The default discovery path is under ~/.openadapt/."""
+        assert DEFAULT_DISCOVERY_PATH.name == "desktop_ipc.json"
+        assert ".openadapt" in str(DEFAULT_DISCOVERY_PATH)
+
+
+class TestIPCClientDiscovery:
+    """Tests for building/refreshing the client from discovery."""
+
+    def test_from_discovery_missing_returns_none(self, tmp_path):
+        """No discovery file → from_discovery returns None."""
+        assert IPCClient.from_discovery(tmp_path / "nope.json") is None
+
+    def test_from_discovery_configures_client(self, tmp_path):
+        """from_discovery wires host/port/token onto the client."""
+        f = tmp_path / "desktop_ipc.json"
+        f.write_text(json.dumps({"port": 40000, "token": "tok"}))
+        client = IPCClient.from_discovery(f)
+        assert client is not None
+        assert client.port == 40000
+        assert client.token == "tok"
+
+    def test_refresh_from_discovery(self, tmp_path):
+        """refresh_from_discovery updates an existing client in place."""
+        f = tmp_path / "desktop_ipc.json"
+        f.write_text(json.dumps({"port": 12345, "token": "t1"}))
+        client = IPCClient()
+        assert client.refresh_from_discovery(f) is True
+        assert client.port == 12345
+        assert client.token == "t1"
+
+    def test_send_attaches_token(self):
+        """send() attaches the client token to a tokenless message."""
+        client = IPCClient(token="sess-xyz")
+        sent = {}
+
+        class FakeSock:
+            def sendall(self, data):
+                sent["data"] = data
+
+        client._socket = FakeSock()
+        assert client.send(IPCMessage(type=IPCMessageType.PAUSE_SYNC)) is True
+        payload = json.loads(sent["data"].decode().strip())
+        assert payload["token"] == "sess-xyz"
+        assert payload["type"] == "pause_sync"
+
+    def test_command_helpers_send_correct_types(self):
+        """The new command helpers emit the right message types."""
+        client = IPCClient(token="t")
+        seen = []
+
+        class FakeSock:
+            def sendall(self, data):
+                seen.append(json.loads(data.decode().strip())["type"])
+
+        client._socket = FakeSock()
+        client.send_open_workflow_library()
+        client.send_open_teach("wf-1")
+        client.send_pause_sync()
+        client.send_resume_sync()
+        assert seen == [
+            "open_workflow_library",
+            "open_teach",
+            "pause_sync",
+            "resume_sync",
+        ]

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -1,0 +1,46 @@
+"""Tests for OS keychain access to the ingest token."""
+
+from unittest.mock import patch
+
+
+from openadapt_tray import keychain
+
+
+class TestIngestToken:
+    def test_env_var_takes_precedence(self, monkeypatch):
+        """OPENADAPT_INGEST_TOKEN env var wins over the keychain."""
+        monkeypatch.setenv(keychain.ENV_INGEST_TOKEN, "env-token")
+        with patch.object(keychain, "keyring") as mock_keyring:
+            token = keychain.get_ingest_token("https://example.test")
+        assert token == "env-token"
+        mock_keyring.get_password.assert_not_called()
+
+    def test_reads_from_keyring(self, monkeypatch):
+        """Falls back to the keychain when no env var is set."""
+        monkeypatch.delenv(keychain.ENV_INGEST_TOKEN, raising=False)
+        with patch.object(keychain, "KEYRING_AVAILABLE", True), patch.object(
+            keychain, "keyring"
+        ) as mock_keyring:
+            mock_keyring.get_password.return_value = "kc-token"
+            token = keychain.get_ingest_token("https://example.test/")
+        assert token == "kc-token"
+        # Account key is the host with any trailing slash stripped.
+        mock_keyring.get_password.assert_called_once_with(
+            keychain.KEYCHAIN_SERVICE, "https://example.test"
+        )
+
+    def test_missing_returns_none(self, monkeypatch):
+        monkeypatch.delenv(keychain.ENV_INGEST_TOKEN, raising=False)
+        with patch.object(keychain, "KEYRING_AVAILABLE", True), patch.object(
+            keychain, "keyring"
+        ) as mock_keyring:
+            mock_keyring.get_password.return_value = None
+            assert keychain.get_ingest_token("https://example.test") is None
+
+    def test_shared_service_name_matches_desktop(self):
+        """The keychain service must match the desktop app's store (§3a)."""
+        assert keychain.KEYCHAIN_SERVICE == "ai.openadapt.desktop"
+
+    def test_has_ingest_token(self, monkeypatch):
+        monkeypatch.setenv(keychain.ENV_INGEST_TOKEN, "x")
+        assert keychain.has_ingest_token("https://example.test") is True

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,7 +1,6 @@
 """Tests for menu construction."""
 
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 
 from openadapt_tray.state import TrayState, AppState
 from openadapt_tray.menu import MenuBuilder, CaptureInfo
@@ -41,7 +40,6 @@ class TestMenuBuilder:
 
     def test_build_returns_menu(self):
         """Test that build returns a pystray Menu."""
-        import pystray
 
         app = self.create_mock_app()
         builder = MenuBuilder(app)
@@ -80,26 +78,51 @@ class TestMenuBuilder:
 
         assert "Starting" in str(item.text)
 
-    def test_training_item_when_idle(self):
-        """Test training item when not training."""
-        app = self.create_mock_app(AppState(state=TrayState.IDLE))
+    def test_recording_item_when_compiling(self):
+        """Test recording item shows 'Compiling' when compiling."""
+        app = self.create_mock_app(AppState(state=TrayState.COMPILING))
         builder = MenuBuilder(app)
 
-        item = builder._build_training_item(app.state.current)
+        item = builder._build_recording_item(app.state.current)
 
-        assert "Training" in str(item.text)
+        assert "Compiling" in str(item.text)
 
-    def test_training_item_when_training(self):
-        """Test training item shows progress when training."""
+    def test_break_item_absent_without_breaks(self):
+        """No needs-attention item when there are no breaks."""
+        app = self.create_mock_app(AppState(state=TrayState.IDLE, break_count=0))
+        builder = MenuBuilder(app)
+
+        assert builder._build_break_item(app.state.current) is None
+
+    def test_break_item_present_with_breaks(self):
+        """Needs-attention item shows the count when breaks exist."""
+        app = self.create_mock_app(AppState(state=TrayState.IDLE, break_count=2))
+        builder = MenuBuilder(app)
+
+        item = builder._build_break_item(app.state.current)
+        assert item is not None
+        assert "2" in str(item.text)
+        assert "need attention" in str(item.text)
+
+    def test_sync_item_offline_disabled(self):
+        """Sync item is disabled and labelled offline when offline."""
+        from openadapt_tray.state import SyncState
+
         app = self.create_mock_app(
-            AppState(state=TrayState.TRAINING, training_progress=0.5)
+            AppState(state=TrayState.IDLE, sync_state=SyncState.OFFLINE)
         )
         builder = MenuBuilder(app)
 
-        item = builder._build_training_item(app.state.current)
+        item = builder._build_sync_item(app.state.current)
+        assert "offline" in str(item.text).lower()
 
-        # Should show percentage
-        assert "50%" in str(item.text) or "Training" in str(item.text)
+    def test_sync_item_pause_when_online(self):
+        """Sync item offers Pause Sync when online."""
+        app = self.create_mock_app(AppState(state=TrayState.IDLE))
+        builder = MenuBuilder(app)
+
+        item = builder._build_sync_item(app.state.current)
+        assert "Pause Sync" in str(item.text)
 
     def test_get_recent_captures_empty(self):
         """Test get_recent_captures returns empty list when no captures."""
@@ -110,15 +133,39 @@ class TestMenuBuilder:
 
         assert captures == []
 
-    @patch("webbrowser.open")
-    def test_open_dashboard(self, mock_webbrowser):
-        """Test open_dashboard opens browser."""
+    def test_open_desktop_app_delegates(self):
+        """Test the desktop-app menu action delegates to the app."""
         app = self.create_mock_app()
         builder = MenuBuilder(app)
 
-        builder._open_dashboard()
+        builder._open_desktop_app()
 
-        app._open_dashboard.assert_called_once()
+        app.open_desktop_app.assert_called_once()
+
+    def test_open_cloud_dashboard_delegates(self):
+        """Test the cloud-dashboard menu action delegates to the app."""
+        app = self.create_mock_app()
+        builder = MenuBuilder(app)
+
+        builder._open_cloud_dashboard()
+
+        app.open_cloud_dashboard.assert_called_once()
+
+    def test_login_delegates(self):
+        """Test the login menu action delegates to the app."""
+        app = self.create_mock_app()
+        builder = MenuBuilder(app)
+
+        builder._login()
+
+        app.login.assert_called_once()
+
+    def test_build_full_menu(self):
+        """The full menu builds without error in an idle state."""
+        app = self.create_mock_app(AppState(state=TrayState.IDLE, break_count=1))
+        builder = MenuBuilder(app)
+        menu = builder.build()
+        assert menu is not None
 
     def test_quit_calls_app_quit(self):
         """Test quit calls app.quit."""

--- a/tests/test_public_metadata.py
+++ b/tests/test_public_metadata.py
@@ -1,0 +1,32 @@
+"""Keep public package metadata aligned with the hosted-rewire boundary."""
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_public_metadata_identifies_unreleased_supporting_surface() -> None:
+    readme = (ROOT / "README.md").read_text()
+    pyproject = (ROOT / "pyproject.toml").read_text()
+
+    assert "Lifecycle: Experimental supporting surface" in readme
+    assert "feat/hosted-rewire" in readme
+    assert "openadapt-flow" in readme
+    assert "Development Status :: 2 - Pre-Alpha" in pyproject
+    assert "Experimental status and launcher companion" in pyproject
+    assert "openadapt train" not in readme
+    assert "Training Control" not in readme
+    assert "monitoring training" not in readme
+
+
+def test_readme_local_links_exist() -> None:
+    readme = (ROOT / "README.md").read_text()
+    links = re.findall(r"\[[^]]*\]\(([^)]+)\)", readme)
+
+    for link in links:
+        target = link.split("#", 1)[0]
+        if not target or "://" in target or target.startswith("mailto:"):
+            continue
+        assert (ROOT / target).exists(), f"README link does not exist: {link}"

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -16,7 +16,11 @@ def test_release_versions_are_synchronized() -> None:
 
 def test_semantic_release_refreshes_and_stages_lock_before_tagging() -> None:
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
-    assert 'version_variables = ["src/openadapt_tray/__init__.py:__version__"]' in pyproject
+    assert (
+        'version_variables = ["src/openadapt_tray/__init__.py:__version__"]'
+        in pyproject
+    )
+    assert re.search(r"(?m)^major_on_zero\s*=\s*false\s*$", pyproject)
     assert 'uv lock --upgrade-package "$PACKAGE_NAME"' in pyproject
     assert "git add uv.lock" in pyproject
     assert "uv build --wheel --sdist" in pyproject
@@ -27,3 +31,10 @@ def test_release_actions_are_pinned_to_commits() -> None:
     uses = re.findall(r"^\s*uses:\s+\S+@([^\s#]+)", workflow, flags=re.MULTILINE)
     assert uses
     assert all(re.fullmatch(r"[0-9a-f]{40}", revision) for revision in uses)
+
+
+def test_release_uses_protected_branch_credential_everywhere() -> None:
+    workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    assert "token: ${{ secrets.ADMIN_TOKEN }}" in workflow
+    assert workflow.count("github_token: ${{ secrets.ADMIN_TOKEN }}") == 2
+    assert "secrets.GITHUB_TOKEN" not in workflow

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -20,6 +20,7 @@ def test_semantic_release_refreshes_and_stages_lock_before_tagging() -> None:
         'version_variables = ["src/openadapt_tray/__init__.py:__version__"]'
         in pyproject
     )
+    assert re.search(r"(?m)^allow_zero_version\s*=\s*true\s*$", pyproject)
     assert re.search(r"(?m)^major_on_zero\s*=\s*false\s*$", pyproject)
     assert 'uv lock --upgrade-package "$PACKAGE_NAME"' in pyproject
     assert "git add uv.lock" in pyproject

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -1,0 +1,29 @@
+"""Regression tests for versioned release inputs."""
+
+import re
+from pathlib import Path
+
+from scripts.check_release_consistency import release_versions
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_release_versions_are_synchronized() -> None:
+    versions = release_versions()
+    assert len(set(versions.values())) == 1, versions
+
+
+def test_semantic_release_refreshes_and_stages_lock_before_tagging() -> None:
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'version_variables = ["src/openadapt_tray/__init__.py:__version__"]' in pyproject
+    assert 'uv lock --upgrade-package "$PACKAGE_NAME"' in pyproject
+    assert "git add uv.lock" in pyproject
+    assert "uv build --wheel --sdist" in pyproject
+
+
+def test_release_actions_are_pinned_to_commits() -> None:
+    workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    uses = re.findall(r"^\s*uses:\s+\S+@([^\s#]+)", workflow, flags=re.MULTILINE)
+    assert uses
+    assert all(re.fullmatch(r"[0-9a-f]{40}", revision) for revision in uses)

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,9 +1,6 @@
 """Tests for hotkey/shortcut handling."""
 
-import pytest
 from unittest.mock import patch, MagicMock
-import threading
-import time
 
 from openadapt_tray.shortcuts import HotkeyManager, HotkeyConfig
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,26 +1,50 @@
 """Tests for state management."""
 
-import pytest
 
-from openadapt_tray.state import TrayState, AppState, StateManager
+from openadapt_tray.state import (
+    TrayState,
+    SyncState,
+    AppState,
+    StateManager,
+    LANE_CLOUD,
+    LANE_BYOC,
+)
 
 
 class TestTrayState:
     """Tests for TrayState enum."""
 
     def test_all_states_defined(self):
-        """Verify all expected states are defined."""
+        """Verify all expected recording-lifecycle states are defined."""
         expected_states = [
             "IDLE",
             "RECORDING_STARTING",
             "RECORDING",
             "RECORDING_STOPPING",
-            "TRAINING",
-            "TRAINING_PAUSED",
+            "COMPILING",
             "ERROR",
         ]
         actual_states = [s.name for s in TrayState]
         assert actual_states == expected_states
+
+    def test_rl_states_removed(self):
+        """The retired RL training states must not exist."""
+        names = [s.name for s in TrayState]
+        assert "TRAINING" not in names
+        assert "TRAINING_PAUSED" not in names
+
+
+class TestSyncState:
+    """Tests for the orthogonal SyncState channel."""
+
+    def test_sync_states_defined(self):
+        """Verify the sync channel states."""
+        names = {s.name for s in SyncState}
+        assert names == {"SYNCED", "SYNCING", "OFFLINE"}
+
+    def test_pushing_is_syncing_alias(self):
+        """PUSHING is a spec alias for SYNCING."""
+        assert SyncState.PUSHING() is SyncState.SYNCING
 
 
 class TestAppState:
@@ -31,8 +55,10 @@ class TestAppState:
         state = AppState()
         assert state.state == TrayState.IDLE
         assert state.current_capture is None
-        assert state.training_progress is None
         assert state.error_message is None
+        assert state.sync_state == SyncState.SYNCED
+        assert state.break_count == 0
+        assert state.deployment_lane == LANE_CLOUD
 
     def test_can_start_recording_when_idle(self):
         """Test that recording can start when idle."""
@@ -60,21 +86,28 @@ class TestAppState:
         assert AppState(state=TrayState.RECORDING_STARTING).is_recording() is True
         assert AppState(state=TrayState.RECORDING_STOPPING).is_recording() is True
         assert AppState(state=TrayState.IDLE).is_recording() is False
-        assert AppState(state=TrayState.TRAINING).is_recording() is False
+        assert AppState(state=TrayState.COMPILING).is_recording() is False
 
-    def test_is_training_states(self):
-        """Test is_training for various states."""
-        assert AppState(state=TrayState.TRAINING).is_training() is True
-        assert AppState(state=TrayState.TRAINING_PAUSED).is_training() is True
-        assert AppState(state=TrayState.IDLE).is_training() is False
-        assert AppState(state=TrayState.RECORDING).is_training() is False
+    def test_is_compiling(self):
+        """Test is_compiling for various states."""
+        assert AppState(state=TrayState.COMPILING).is_compiling() is True
+        assert AppState(state=TrayState.RECORDING).is_compiling() is False
 
     def test_is_busy_states(self):
         """Test is_busy for various states."""
         assert AppState(state=TrayState.IDLE).is_busy() is False
         assert AppState(state=TrayState.ERROR).is_busy() is False
         assert AppState(state=TrayState.RECORDING).is_busy() is True
-        assert AppState(state=TrayState.TRAINING).is_busy() is True
+        assert AppState(state=TrayState.COMPILING).is_busy() is True
+
+    def test_sync_and_break_helpers(self):
+        """Test the orthogonal sync + break helpers."""
+        assert AppState(sync_state=SyncState.SYNCING).is_syncing() is True
+        assert AppState(sync_state=SyncState.OFFLINE).is_offline() is True
+        assert AppState(break_count=3).has_breaks() is True
+        assert AppState(break_count=0).has_breaks() is False
+        assert AppState(deployment_lane=LANE_BYOC).is_byoc() is True
+        assert AppState(deployment_lane=LANE_CLOUD).is_byoc() is False
 
 
 class TestStateManager:
@@ -159,3 +192,51 @@ class TestStateManager:
         # Should not raise
         manager.transition(TrayState.RECORDING)
         assert manager.current.state == TrayState.RECORDING
+
+    def test_transition_preserves_orthogonal_channels(self):
+        """Recording transitions must not clobber sync/break/lane."""
+        manager = StateManager()
+        manager.set_sync_state(SyncState.SYNCING)
+        manager.set_break_count(4)
+        manager.set_deployment_lane(LANE_BYOC)
+
+        manager.transition(TrayState.RECORDING, current_capture="w")
+
+        assert manager.current.state == TrayState.RECORDING
+        assert manager.current.sync_state == SyncState.SYNCING
+        assert manager.current.break_count == 4
+        assert manager.current.deployment_lane == LANE_BYOC
+
+    def test_set_sync_state_preserves_recording(self):
+        """Sync updates must not clobber the recording lifecycle."""
+        manager = StateManager()
+        manager.transition(TrayState.RECORDING, current_capture="w")
+        manager.set_sync_state(SyncState.OFFLINE)
+
+        assert manager.current.state == TrayState.RECORDING
+        assert manager.current.current_capture == "w"
+        assert manager.current.sync_state == SyncState.OFFLINE
+
+    def test_set_break_count_clamps_and_notifies(self):
+        """Break count updates clamp to >=0 and notify listeners once."""
+        manager = StateManager()
+        received = []
+        manager.add_listener(lambda s: received.append(s.break_count))
+
+        manager.set_break_count(3)
+        manager.set_break_count(3)  # no change → no extra notification
+        manager.set_break_count(-5)  # clamps to 0
+
+        assert manager.current.break_count == 0
+        assert received == [3, 0]
+
+    def test_reset_preserves_sync_channel(self):
+        """reset() returns recording to IDLE but keeps the sync channel."""
+        manager = StateManager()
+        manager.set_sync_state(SyncState.SYNCING)
+        manager.transition(TrayState.RECORDING, current_capture="w")
+        manager.reset()
+
+        assert manager.current.state == TrayState.IDLE
+        assert manager.current.current_capture is None
+        assert manager.current.sync_state == SyncState.SYNCING

--- a/uv.lock
+++ b/uv.lock
@@ -423,6 +423,9 @@ macos-native = [
     { name = "pyobjc-framework-cocoa" },
     { name = "rumps" },
 ]
+release = [
+    { name = "uv" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -439,6 +442,7 @@ requires-dist = [
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.10.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "rumps", marker = "extra == 'macos-native'", specifier = ">=0.4.0" },
+    { name = "uv", marker = "extra == 'release'", specifier = "==0.11.26" },
 ]
 
 [[package]]
@@ -876,6 +880,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614 },
+]
+
+[[package]]
+name = "uv"
+version = "0.11.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/cb/5efc713948ddb10b00abfb51bfd429221c720175557f9c7965fea2448fe4/uv-0.11.26.tar.gz", hash = "sha256:2a433ece2ace088dd572d8abb0e6bd9a4ecb0e10bc9856447bbb37545f384f29", size = 4331220 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/71/86dbffac9e26df28a16639c426cf4ba572aaf43d9231463e0dca337895b2/uv-0.11.26-py3-none-linux_armv6l.whl", hash = "sha256:fb97bf04512dfe16d86084e75d8129701fc8da9fb40de8746b73c3aa617c5897", size = 25197324 },
+    { url = "https://files.pythonhosted.org/packages/ec/80/525b73c8188e7052343e7109466a08fcd5195055aff4b0346ce3622e48cb/uv-0.11.26-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a58a06e5a4b0035538d3ab4160ad74c716076ea7148eb3317171c6276ac020b4", size = 24179172 },
+    { url = "https://files.pythonhosted.org/packages/7b/5e/cf7b94ed3b1932c2a62573dcd388ad6c1da5c52111cd71ab7f20faa4a0aa/uv-0.11.26-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7b6d078d2ce83897884c2330c0676f27be4bf3d223fb2a409460f579fb5f0a98", size = 22949576 },
+    { url = "https://files.pythonhosted.org/packages/bf/fd/71fa021f6909c4139d8354bea623b5e0ef0ce4a08da250da1a1645528da2/uv-0.11.26-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:1cd9ba4951681ce17f1703106266fcbe27aaa7d37f07d53cce8b5686d68a8755", size = 24936673 },
+    { url = "https://files.pythonhosted.org/packages/7d/5e/273425e58a8812423e3d1f6c5da1015e636fbf13a83d104317ca37e16304/uv-0.11.26-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:e4f4c3268e69ac96f01972274a62f5f930c03cbc680adba6f21e63237ba3a639", size = 24719617 },
+    { url = "https://files.pythonhosted.org/packages/81/f8/1601e2acc7c54963814b4831eab996d8599e690712722c5acec5114860be/uv-0.11.26-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:efcbe0e187846f5ddba23bcaed17e4f9cd2463da5c45bdb5869616f686d713ff", size = 24734176 },
+    { url = "https://files.pythonhosted.org/packages/88/d2/a8a422e54c08cf4b8d51bedb9dbdd3cc233aa290ad8b3ee0438c0c02a3a5/uv-0.11.26-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:120ab2de93164d08cf5950f7fe18cbebe3ff670865ae41a292452bab2346477f", size = 26158780 },
+    { url = "https://files.pythonhosted.org/packages/db/e6/647fe5fdc888a3d27f79977877ce4e88052fe9be5398371e51bb134fc262/uv-0.11.26-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9052bf27c7ee426901f35a48715fa9288ce631c1878b91c9a6c950288f4b8633", size = 27009550 },
+    { url = "https://files.pythonhosted.org/packages/72/c2/85d8e762ad83b0f14fae2255b0578c4fd7dc915746f81b64ed786342627a/uv-0.11.26-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:efdddfcc9b1b790c5f7985c5c183c851682ced165b44ffa914f4947f5cad1fbf", size = 26183777 },
+    { url = "https://files.pythonhosted.org/packages/d3/00/478c3a870dcac690b8c337ee950a60a952e817f574945e85155c3cc0ab34/uv-0.11.26-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4dcf4e0b5b5cbdc242dcb002f1f8d99e7cf8c043609869228a9ce15e095c0b18", size = 26260589 },
+    { url = "https://files.pythonhosted.org/packages/a7/51/e4e43e106fb8cdc026b97491ea4600f4194a9c4da0b4e4e30c2a7dceb268/uv-0.11.26-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:866ae8d28f7381c15de0906a284c1e97916424c635bf40f7960b3fc889cd725e", size = 25073850 },
+    { url = "https://files.pythonhosted.org/packages/f2/c2/e772b7e6c8a835e8bf6739a391cdfc8e8e244c5c496d9b40625068b59ff4/uv-0.11.26-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:22f6d62e794b252ff3a1e2dfe5010cc76208f90b2c906e54971a0223ad6f16bc", size = 25682609 },
+    { url = "https://files.pythonhosted.org/packages/1a/69/ea77209a224a23a399cb7f6414f77ef032bd9e083e01199a0ebebf0d3ff2/uv-0.11.26-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:edd0c12b75141a6d830d138a91e366ad66e630f1c1dcaf83b8325b80cbacfcbb", size = 25800556 },
+    { url = "https://files.pythonhosted.org/packages/77/60/b6c0c03d2538a016b6624fa251960012e564ea02f841e958c7d60e974685/uv-0.11.26-py3-none-musllinux_1_1_i686.whl", hash = "sha256:af6a45b11a569cc4d2437e89a25a53dcf753f2a02a8f2de96be09b9b942cb3ec", size = 25385658 },
+    { url = "https://files.pythonhosted.org/packages/8d/e7/46881ff9164aa2e7c649901837d58eee3c57beb3b0fcc0fea6a4e40cf8f3/uv-0.11.26-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:c28822517d03aebbe9549aaaecc88ad580e4b2b6a927abffe5774a74d6ba09f6", size = 26551013 },
+    { url = "https://files.pythonhosted.org/packages/d6/94/380dad6c2bbe12417025aacd12cfc08322ed4c9dd8f760bff7035b86f22d/uv-0.11.26-py3-none-win32.whl", hash = "sha256:79e5c1b3410047e1962290c3b7b8f512d2c1bb95200c60b016f7729287cf34c0", size = 23947180 },
+    { url = "https://files.pythonhosted.org/packages/d0/13/9c588226d5b478328d739e654944430719f3ffe8999d6a24d425ec9664ab/uv-0.11.26-py3-none-win_amd64.whl", hash = "sha256:d95567e9470dc48ff03265f420c3c6973f6437f18a79d5e00b6eb4b2d9379907", size = 26909320 },
+    { url = "https://files.pythonhosted.org/packages/21/1d/ea66b12813878797126e2b3aca124b1c9c5ef53120702d1c00172f90a21d/uv-0.11.26-py3-none-win_arm64.whl", hash = "sha256:7e69d1569afbb936e7bf4e4ab2f72d606405f4a68f380f088a0b2233e84e056a", size = 25176820 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2,12 +2,115 @@ version = 1
 requires-python = ">=3.10"
 
 [[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813 },
+]
+
+[[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181 },
+]
+
+[[package]]
 name = "bidict"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/6e/026678aa5a830e07cd9498a05d3e7e650a4f56a42f267a53d22bcda1bdc9/bidict-0.23.1.tar.gz", hash = "sha256:03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71", size = 29093 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/37/e8730c3587a65eb5645d4aba2d27aae48e8003614d6aaf15dda67f702f1f/bidict-0.23.1-py3-none-any.whl", hash = "sha256:5dae8d4d79b552a71cbabc7deb25dfe8ce710b17ff41711e13010ead2abfc3e5", size = 32764 },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289 },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/a9/02cae418ec4beb282ace11958d9d4737793439d561fadc7e6d56f2e2b354/cffi-2.1.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:c941bb58d5a6e1c3892d86e42927ed6c180302f07e6d395d08c416e594b98b46", size = 211107 },
+    { url = "https://files.pythonhosted.org/packages/3b/30/c806937ed5e4c2c7ac30d9d6b76b5dc57ff8b75d83800d9bb11a8253cf2a/cffi-2.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a016194dbe13d14ee9556e734b772d8d67b947092b268d757fd4290e3ba2dfc2", size = 218733 },
+    { url = "https://files.pythonhosted.org/packages/f9/cf/398272b8bbfd58aa314fda5a7f1cdbb26d1d78ae324a11211521315dd1f0/cffi-2.1.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:03e9810d18c646077e501f661b682fbf5dee4676048527ca3cffe66faa9960dd", size = 205543 },
+    { url = "https://files.pythonhosted.org/packages/45/ca/f91641185cdd90c36d317a9dc7f85e88ef8682d8b300977baff5e23c35d8/cffi-2.1.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:19c54ac121cad98450b4896fa9a43ee0180d57bc4bc911a33db6cab1efab6cd3", size = 205460 },
+    { url = "https://files.pythonhosted.org/packages/38/66/04781a77b411f0bb5b234d62c1814754ab75ebe455ccff1b08e8d7aae98f/cffi-2.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d433a51f1870e43a13b6732f92aaf540ff77c2015097c78556f75a2d6c030e0", size = 218760 },
+    { url = "https://files.pythonhosted.org/packages/d0/9a/bb1d5ed9c3fcae158e9f6391bf309c95d98c2ac37ed56573228471d0af5e/cffi-2.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3d7f118b5adbfdfead90c25822690b02bc8074fba949bb7858bec4ebd55adb43", size = 221230 },
+    { url = "https://files.pythonhosted.org/packages/41/aa/3c1409cdd26094efacd1c36c66e0a6eb9d4296e4fd4f9901b8b2042f4323/cffi-2.1.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c5f5df567f6eb216de69be06ce55c8b714090fae02b18a3b40da8163b8c5fa9c", size = 213524 },
+    { url = "https://files.pythonhosted.org/packages/fa/75/74dfb7c3fc6ebbd408038476bd4c1d7e925c62614e7b9c534ecc34218288/cffi-2.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:11b3fb55f4f8ad92274ed26705f65d8f91457de71f5380061eb6d125a768fecd", size = 220341 },
+    { url = "https://files.pythonhosted.org/packages/65/68/9f3ef890cf3c6ab97bd531c5677f67613d302165d16f8142b2811782a614/cffi-2.1.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:30b65779d598c370374fefabf138d456fd6f3216bfa7bedfab1ba82025b0cd93", size = 211892 },
+    { url = "https://files.pythonhosted.org/packages/22/d7/1a74539db16d8bfd839ff1515948948efbb162e574650fd3d846896eea95/cffi-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88023dfe18799507b73f1dbb0d14326a17465de1bc9c9c7655c22845e9ddc3a2", size = 218793 },
+    { url = "https://files.pythonhosted.org/packages/ec/d1/9a5b7169499e8e8d8e636de70b97ac7c9447104d2ff1a2cd94790cea5162/cffi-2.1.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:0a96b74cda968eebbad56d973efe5098974f0a9fb323865bf99ea1fd24e3e64c", size = 205737 },
+    { url = "https://files.pythonhosted.org/packages/ba/b0/e131a9c41f10607926278453d9596163594fe1c4ebc46efe3b5e5b34eb84/cffi-2.1.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a5781494d4d400a3f47f8f1da94b324f6e6b440a53387774002890a2a2f4b50f", size = 204909 },
+    { url = "https://files.pythonhosted.org/packages/fb/d2/4398416cd699b35167947c6e22aca52c47e69ad5695073c9f1f2c52e04aa/cffi-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aa7a1b53a2a4452ada2d1b5dade9960b2522f1e61293a811a077439e39029565", size = 217883 },
+    { url = "https://files.pythonhosted.org/packages/a2/a5/d4fe77b589e5e82d43ebc809bf2e6474afe8e48e32ea050b9357645b6471/cffi-2.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9d8272c0e483b024e1b9ad029821470ed8ec65631dbd90217469da0e7cd89f1c", size = 221251 },
+    { url = "https://files.pythonhosted.org/packages/22/f0/a2fc43084c0433caf7f461bccc013e28f848d04ee1c5ed7fce71423cf4d9/cffi-2.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7762faa47e8ff7eb80bd261d9a7d8eea2d8baa69de5e95b70c1f338bbe712f02", size = 214250 },
+    { url = "https://files.pythonhosted.org/packages/04/8c/b925975448cf20634a9fbd5efceb807219db452653648d2897c0989cab2d/cffi-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:89095c1968b4ba8285840e131bf2891b09ae137fe2146905acae0354fbce1b5e", size = 219441 },
+    { url = "https://files.pythonhosted.org/packages/c3/c0/d1ec30ffb370f748f2fb54425972bfef9871e0132e82fb589c46b6676049/cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d", size = 214815 },
+    { url = "https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7", size = 222429 },
+    { url = "https://files.pythonhosted.org/packages/4b/a4/77b53abbf7a1e0beb9637edbef2a94d15f9c822f591e85d439ffd91519a6/cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b", size = 210315 },
+    { url = "https://files.pythonhosted.org/packages/58/0c/f528df19cc94b675087324d4760d9e6d5bfae97d6217aa4fac43de4f5fcc/cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7", size = 208859 },
+    { url = "https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66", size = 221844 },
+    { url = "https://files.pythonhosted.org/packages/6e/28/bd53988b9833e8f8ad539d26f4c07a6b3f6bcb1e9e02e7ca038250b3428d/cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe", size = 225287 },
+    { url = "https://files.pythonhosted.org/packages/79/99/0d0fd37f055224085f42bbb2c022d002e17dde4a97972822327b07d84101/cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b", size = 223681 },
+    { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331 },
+    { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966 },
+    { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747 },
+    { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392 },
+    { url = "https://files.pythonhosted.org/packages/88/f6/01890cfd63c08f8eb96a8319b0443690197d240a8bd6346048cf7bde9190/cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d", size = 210285 },
+    { url = "https://files.pythonhosted.org/packages/a6/cf/2b684132056f438567b61e19d690dd31cd0921ace051e0a458be6074369e/cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0", size = 208801 },
+    { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808 },
+    { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241 },
+    { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588 },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142 },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819 },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353 },
+    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051 },
+    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630 },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593 },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146 },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240 },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899 },
+    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652 },
+    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755 },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933 },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749 },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703 },
+    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121 },
+    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820 },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342 },
+    { url = "https://files.pythonhosted.org/packages/eb/d8/df4543cc087245044ed02ef3ad8e0a26619d0075ac7a77a12dc81177851b/cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022", size = 210073 },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/fac738d73728c6cea2a88a2883dca54892496cbba88a1dc1f2909cb8a6f5/cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0", size = 208551 },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649 },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203 },
+    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263 },
+    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904 },
+    { url = "https://files.pythonhosted.org/packages/8b/31/e115c985105dd7ffb32444505f18ceb874bb42d992af05d5dced7ecf1980/cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8", size = 211554 },
+    { url = "https://files.pythonhosted.org/packages/5a/67/9e6e09409336d9e515c58367e7cfcf4f89df06ad25252675595a58eb59d5/cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd", size = 210795 },
+    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843 },
+    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773 },
+    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719 },
 ]
 
 [[package]]
@@ -29,6 +132,55 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978 },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422 },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503 },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779 },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683 },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874 },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283 },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844 },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290 },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612 },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804 },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835 },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239 },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593 },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961 },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145 },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719 },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209 },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285 },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441 },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869 },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948 },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429 },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968 },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758 },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863 },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983 },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173 },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298 },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338 },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650 },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820 },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968 },
+    { url = "https://files.pythonhosted.org/packages/d6/a7/f9dac0ab7f80368c56993a7bf638ef9935f825c91902798481fac0898138/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838", size = 4676239 },
+    { url = "https://files.pythonhosted.org/packages/d7/70/2ba3769dd0ae167e2f33dfa9592d45db6ff9a61d62ca1a5b3d1bdd09068f/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5", size = 4715584 },
+    { url = "https://files.pythonhosted.org/packages/94/64/2923570ac1c0bd3a737aa366ac3abbbbde273042308b8cde95e2364a6e6a/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615", size = 4675885 },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/614dc7e051418cfe53d55173c1e24c6b0085e89996fe90508c2fdf769aef/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6", size = 4715449 },
 ]
 
 [[package]]
@@ -105,6 +257,64 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515 },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784 },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455 },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789 },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -114,12 +324,86 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777 },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871 },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/1f/c23395957d41ccf27c4e535c3d334c4051e5395b3752057ba4cbaec35c56/jaraco_functools-4.6.0.tar.gz", hash = "sha256:880c577ec9720b3a052d5bc611fb9f2269b3d87902ef42440df443b88e443280", size = 20837 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl", hash = "sha256:99e3dc0060c5cbe8fcd1cdb36258e2a65ca40f1566b2033b12abb1bb44dd3c30", size = 11677 },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010 },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160 },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226 },
+]
+
+[[package]]
 name = "openadapt-tray"
-version = "0.1.0"
+version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "desktop-notifier" },
+    { name = "httpx" },
+    { name = "keyring" },
     { name = "pillow" },
     { name = "pynput" },
     { name = "pystray" },
@@ -144,6 +428,8 @@ macos-native = [
 requires-dist = [
     { name = "click", specifier = ">=8.0.0" },
     { name = "desktop-notifier", specifier = ">=6.2.0" },
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "keyring", specifier = ">=24.0" },
     { name = "openadapt-tray", extras = ["macos-native"], marker = "extra == 'all'" },
     { name = "pillow", specifier = ">=9.0.0" },
     { name = "pynput", specifier = ">=1.7.0" },
@@ -269,6 +555,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172 },
 ]
 
 [[package]]
@@ -446,6 +741,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756 },
+]
+
+[[package]]
 name = "rubicon-objc"
 version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -488,6 +792,19 @@ dependencies = [
     { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/e2/2e6a47951290bd1a2831dcc50aec4b25d104c0cf00e8b7868cbd29cf3bfe/rumps-0.4.0.tar.gz", hash = "sha256:17fb33c21b54b1e25db0d71d1d793dc19dc3c0b7d8c79dc6d833d0cffc8b1596", size = 39257 }
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554 },
+]
 
 [[package]]
 name = "six"
@@ -715,4 +1032,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/68/43/c81672457002908b8c0f1e4672db1d0b8885c2894c6768fe9b0162af9ee5/winrt_windows_ui_notifications-3.2.1-cp314-cp314-win32.whl", hash = "sha256:00a7579ca0870134c27def1418c259fb18efe5b88aa399de85b4712f1add1b55", size = 157561 },
     { url = "https://files.pythonhosted.org/packages/17/d8/910a58698d722120f2401c3bfeb6018361d92f3b2814caae839f54693305/winrt_windows_ui_notifications-3.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:943599c727abf710ae94644b1d521e11857bd568e080e894a8be11aa717e383a", size = 170152 },
     { url = "https://files.pythonhosted.org/packages/b5/a3/1db0f2ec28a4eadd0876c0ac3a3d78514027c5afe35737b164e03c98b234/winrt_windows_ui_notifications-3.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:2a496c7e796b537966df7b26753b20bc40c5c1fbe96b3b3051a1debc00b80f07", size = 163245 },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238 },
 ]


### PR DESCRIPTION
## What changed

- aligns tray documentation and package metadata with the hosted workflow lifecycle
- adds an explicit MIT license and public metadata regression tests
- retains the existing hosted state, IPC, and break-notification implementation on this branch

## Why

The tray README described an abandoned training workflow and lacked complete public package metadata.

## Impact

The tray is clearly positioned as an Experimental companion surface rather than a canonical engine or production runner.

## Validation

- 137 tests passed, 2 skipped
