### PR TITLE
fix: recover tray 0.1.1 PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,10 +80,12 @@ commit_message = "chore: release {version}"
 allow_zero_version = true
 major_on_zero = false
 build_command = """
-python -m pip install --disable-pip-version-check -e '.[release]'
-uv lock --upgrade-package "$PACKAGE_NAME"
-git add uv.lock
-uv build --wheel --sdist
+python -m pip install --disable-pip-version-check "uv==0.11.26" &&
+python scripts/check_release_consistency.py --write-lock &&
+uv lock --locked --offline &&
+git add uv.lock &&
+uv build --wheel --sdist &&
+python scripts/check_release_consistency.py --require-dist
 """
 
 [tool.semantic_release.branches.main]

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Check that release version sources and built distributions agree."""
+"""Check and synchronize the versioned inputs used by releases."""
 
 from __future__ import annotations
 
@@ -18,35 +18,125 @@ def _match(pattern: str, text: str, source: str) -> str:
     return match.group(1)
 
 
-def release_versions() -> dict[str, str]:
-    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
-    package_init = (ROOT / "src/openadapt_tray/__init__.py").read_text(
-        encoding="utf-8"
+def _project_identity(root: Path) -> tuple[str, str]:
+    pyproject = (root / "pyproject.toml").read_text(encoding="utf-8")
+    project_table = _match(
+        r"(?ms)^\[project\]\s*$\n(.*?)(?=^\[|\Z)",
+        pyproject,
+        "pyproject.toml [project] table",
     )
-    lock = (ROOT / "uv.lock").read_text(encoding="utf-8")
-
-    return {
-        "pyproject.toml": _match(
-            r"\[project\]\s+name = \"openadapt-tray\"\s+version = \"([^\"]+)\"",
-            pyproject,
+    return (
+        _match(
+            r'(?m)^name\s*=\s*"([^"]+)"\s*$',
+            project_table,
             "pyproject.toml",
         ),
+        _match(
+            r'(?m)^version\s*=\s*"([^"]+)"\s*$',
+            project_table,
+            "pyproject.toml",
+        ),
+    )
+
+
+def _editable_lock_version_span(
+    lock_text: str, package_name: str
+) -> tuple[int, int, str]:
+    package_starts = list(re.finditer(r"(?m)^\[\[package\]\]\s*$", lock_text))
+    matches: list[tuple[int, int, str]] = []
+
+    for index, package_start in enumerate(package_starts):
+        package_end = (
+            package_starts[index + 1].start()
+            if index + 1 < len(package_starts)
+            else len(lock_text)
+        )
+        block = lock_text[package_start.start() : package_end]
+        if not re.search(
+            rf'(?m)^name\s*=\s*"{re.escape(package_name)}"\s*$', block
+        ):
+            continue
+        if not re.search(
+            r'(?m)^source\s*=\s*\{\s*editable\s*=\s*"\."\s*\}\s*$', block
+        ):
+            continue
+
+        version = re.search(r'(?m)^version\s*=\s*"([^"]+)"\s*$', block)
+        if not version:
+            raise ValueError(
+                f"editable {package_name!r} lock entry has no version"
+            )
+        matches.append(
+            (
+                package_start.start() + version.start(1),
+                package_start.start() + version.end(1),
+                version.group(1),
+            )
+        )
+
+    if len(matches) != 1:
+        raise ValueError(
+            f"expected one editable {package_name!r} lock entry, "
+            f"found {len(matches)}"
+        )
+    return matches[0]
+
+
+def release_versions(root: Path = ROOT) -> dict[str, str]:
+    package_name, project_version = _project_identity(root)
+    if package_name != "openadapt-tray":
+        raise ValueError(f"unexpected project name: {package_name!r}")
+
+    package_init = (root / "src/openadapt_tray/__init__.py").read_text(
+        encoding="utf-8"
+    )
+    lock = (root / "uv.lock").read_text(encoding="utf-8")
+    _, _, lock_version = _editable_lock_version_span(lock, package_name)
+
+    return {
+        "pyproject.toml": project_version,
         "src/openadapt_tray/__init__.py": _match(
             r'^__version__ = "([^"]+)"$', package_init, "package __init__"
         ),
-        "uv.lock": _match(
-            r"\[\[package\]\]\s+name = \"openadapt-tray\"\s+version = \"([^\"]+)\""
-            r"\s+source = \{ editable = \"\.\" \}",
-            lock,
-            "uv.lock",
-        ),
+        "uv.lock": lock_version,
     }
+
+
+def synchronize_release_lock(root: Path = ROOT) -> bool:
+    """Stamp only the editable root version, preserving reviewed resolution."""
+    package_name, project_version = _project_identity(root)
+    if package_name != "openadapt-tray":
+        raise ValueError(f"unexpected project name: {package_name!r}")
+
+    lock_path = root / "uv.lock"
+    lock_text = lock_path.read_text(encoding="utf-8")
+    version_start, version_end, lock_version = _editable_lock_version_span(
+        lock_text, package_name
+    )
+    if lock_version == project_version:
+        return False
+
+    lock_path.write_text(
+        lock_text[:version_start] + project_version + lock_text[version_end:],
+        encoding="utf-8",
+    )
+    if release_versions(root)["uv.lock"] != project_version:
+        raise ValueError("failed to synchronize the editable lock version")
+    return True
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--write-lock",
+        action="store_true",
+        help="stamp the project version into the editable root lock entry",
+    )
     parser.add_argument("--require-dist", action="store_true")
     args = parser.parse_args()
+
+    if args.write_lock:
+        synchronize_release_lock()
 
     versions = release_versions()
     unique_versions = set(versions.values())

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -1,9 +1,15 @@
 """Regression tests for versioned release inputs."""
 
 import re
+import shutil
 from pathlib import Path
 
-from scripts.check_release_consistency import release_versions
+import pytest
+
+from scripts.check_release_consistency import (
+    release_versions,
+    synchronize_release_lock,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -22,9 +28,97 @@ def test_semantic_release_refreshes_and_stages_lock_before_tagging() -> None:
     )
     assert re.search(r"(?m)^allow_zero_version\s*=\s*true\s*$", pyproject)
     assert re.search(r"(?m)^major_on_zero\s*=\s*false\s*$", pyproject)
-    assert 'uv lock --upgrade-package "$PACKAGE_NAME"' in pyproject
-    assert "git add uv.lock" in pyproject
-    assert "uv build --wheel --sdist" in pyproject
+    assert "$PACKAGE_NAME" not in pyproject
+    assert "uv lock --upgrade-package" not in pyproject
+
+    install = pyproject.index(
+        'python -m pip install --disable-pip-version-check "uv==0.11.26"'
+    )
+    synchronize = pyproject.index(
+        "python scripts/check_release_consistency.py --write-lock"
+    )
+    validate = pyproject.index("uv lock --locked --offline")
+    stage = pyproject.index("git add uv.lock")
+    build = pyproject.index("uv build --wheel --sdist")
+    verify = pyproject.index(
+        "python scripts/check_release_consistency.py --require-dist"
+    )
+    assert install < synchronize < validate < stage < build < verify
+
+    build_command = re.search(
+        r'(?s)build_command = """(.*?)"""', pyproject
+    )
+    assert build_command
+    commands = [
+        line.strip() for line in build_command.group(1).splitlines() if line.strip()
+    ]
+    assert all(command.endswith("&&") for command in commands[:-1])
+
+
+def _copy_release_inputs(destination: Path) -> None:
+    (destination / "src/openadapt_tray").mkdir(parents=True)
+    shutil.copy(ROOT / "pyproject.toml", destination / "pyproject.toml")
+    shutil.copy(ROOT / "uv.lock", destination / "uv.lock")
+    shutil.copy(
+        ROOT / "src/openadapt_tray/__init__.py",
+        destination / "src/openadapt_tray/__init__.py",
+    )
+
+
+def test_release_bump_synchronizes_only_editable_root_version(tmp_path: Path) -> None:
+    _copy_release_inputs(tmp_path)
+    pyproject_path = tmp_path / "pyproject.toml"
+    package_init_path = tmp_path / "src/openadapt_tray/__init__.py"
+    lock_path = tmp_path / "uv.lock"
+    current_version = release_versions(tmp_path)["pyproject.toml"]
+    simulated_version = "999.999.999"
+
+    pyproject_path.write_text(
+        pyproject_path.read_text(encoding="utf-8").replace(
+            f'version = "{current_version}"',
+            f'version = "{simulated_version}"',
+            1,
+        ),
+        encoding="utf-8",
+    )
+    package_init_path.write_text(
+        package_init_path.read_text(encoding="utf-8").replace(
+            f'__version__ = "{current_version}"',
+            f'__version__ = "{simulated_version}"',
+            1,
+        ),
+        encoding="utf-8",
+    )
+    before = lock_path.read_text(encoding="utf-8")
+
+    assert synchronize_release_lock(tmp_path)
+    after = lock_path.read_text(encoding="utf-8")
+    assert release_versions(tmp_path) == {
+        "pyproject.toml": simulated_version,
+        "src/openadapt_tray/__init__.py": simulated_version,
+        "uv.lock": simulated_version,
+    }
+    assert after == before.replace(
+        f'name = "openadapt-tray"\nversion = "{current_version}"',
+        f'name = "openadapt-tray"\nversion = "{simulated_version}"',
+        1,
+    )
+    assert not synchronize_release_lock(tmp_path)
+
+
+def test_release_lock_sync_rejects_ambiguous_editable_root(tmp_path: Path) -> None:
+    _copy_release_inputs(tmp_path)
+    lock_path = tmp_path / "uv.lock"
+    lock = lock_path.read_text(encoding="utf-8")
+    root_entry = re.search(
+        r'(?ms)^\[\[package\]\]\s*\nname = "openadapt-tray".*?(?=^\[\[package\]\]|\Z)',
+        lock,
+    )
+    assert root_entry
+    lock_path.write_text(lock + "\n" + root_entry.group(0), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="expected one editable"):
+        synchronize_release_lock(tmp_path)
 
 
 def test_release_actions_are_pinned_to_commits() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ wheels = [
 
 [[package]]
 name = "openadapt-tray"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- replace the undefined `$PACKAGE_NAME` lock refresh with a standard-library synchronizer that changes only the unique editable `openadapt-tray` version
- repair the checked-in root lock version from `0.0.1` to the released source version `0.1.0`
- make the semantic-release build chain fail fast, validate the reviewed lock offline, build wheel and sdist, and verify both artifacts before release creation
- add version-independent regression coverage for exact lock mutation, ambiguity refusal, command ordering, and fail-fast chaining

## Recovery semantics

Do not delete or retag the existing GitHub `v0.1.0` release. It records the first release attempt, whose PyPI step never ran. Squash-merge this PR with its exact `fix:` title. Python Semantic Release 9.15.2 then computes `0.1.1` from `v0.1.0` and publishes new immutable GitHub and PyPI artifacts.

## Verification

- exact `python-semantic-release==9.15.2` calculation: `0.1.1`
- temporary semantic-release-style `0.1.1` bump: lock synchronization changed only the editable root version
- empty-cache `uv lock --locked --offline`: passed
- `openadapt_tray-0.1.1` wheel and sdist: built; wheel metadata reports `Version: 0.1.1`
- release-contract tests: 6 passed
- full supported Python 3.12 suite: 142 passed, 2 skipped, with one AppKit GUI setup test deselected because this local sandbox has no GUI session
- Ruff, workflow YAML parsing, checked-in `0.1.0` build, and distribution consistency: passed

## Post-merge verification

- watch the release job through PyPI and GitHub publication
- clean-install `openadapt-tray==0.1.1` from PyPI and verify imported/package metadata versions
- retain `v0.1.0` unchanged as the failed-attempt audit record