### PR TITLE
docs: use canonical 'retained evidence' wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ small needs-attention endpoint.
 
 OpenAdapt compiles demonstrated GUI workflows into deterministic, locally
 executable programs. Healthy runs make no model calls. When an interface
-drifts, OpenAdapt re-resolves from recorded evidence or proposes a governed
+drifts, OpenAdapt re-resolves from retained evidence or proposes a governed
 repair, and halts when verification fails. That workflow logic belongs to
 `openadapt-flow`, not the tray.
 


### PR DESCRIPTION
Part of the 2026-07-19 cross-surface copy-consistency review (`.private/copy_consistency_audit_2026_07_19.md`).

The canonical one-liner in AGENTS.md, the org profile, and `openadapt-flow/docs/LIMITS.md` all say **retained evidence**; the tray README said "recorded evidence". One-word normalization.