### PR TITLE
feat: governed "Grounding Model..." entry point in the tray menu

### DIFF
--- a/src/openadapt_tray/app.py
+++ b/src/openadapt_tray/app.py
@@ -342,6 +342,18 @@ class TrayApplication:
             f"{self.config.hosted_url.rstrip('/')}/dashboard/settings/ingest"
         )
 
+    def open_grounding_settings(self) -> None:
+        """Open the governed Grounding-model settings in the browser.
+
+        The grounding model is an admin-scoped, off-by-default egress capability
+        governed by the cloud control plane (Tier-3 policy). The tray does not
+        edit governed config locally; it opens the canonical dashboard editor,
+        where an org admin can view or change it (members see it read-only).
+        """
+        webbrowser.open(
+            f"{self.config.hosted_url.rstrip('/')}/dashboard/settings"
+        )
+
     def pause_sync(self) -> None:
         """Ask the desktop to pause the upload/sync queue."""
         if self.ipc.is_connected():

--- a/src/openadapt_tray/menu.py
+++ b/src/openadapt_tray/menu.py
@@ -61,6 +61,7 @@ class MenuBuilder:
             self._build_sync_item(state),
             Item("Login...", self._login),
             Item("Settings...", self._open_settings),
+            Item("Grounding Model...", self._open_grounding_settings),
             Menu.SEPARATOR,
             Item("Quit", self._quit),
         ]
@@ -205,6 +206,14 @@ class MenuBuilder:
     def _open_settings(self) -> None:
         """Open settings dialog."""
         self.app.platform.open_settings_dialog(self.app.config)
+
+    def _open_grounding_settings(self) -> None:
+        """Open the governed Grounding-model settings (cloud dashboard).
+
+        Admin-scoped, off-by-default egress capability; the canonical editor is
+        the cloud control plane. The tray never edits governed config locally.
+        """
+        self.app.open_grounding_settings()
 
     def _quit(self) -> None:
         """Quit the application."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -239,3 +239,27 @@ class TestQuit:
         with patch.object(app, "stop_recording") as mock_stop:
             app.quit()
             mock_stop.assert_called_once()
+
+
+class TestGroundingSettings:
+    """Tests for the governed grounding-model settings entry point."""
+
+    @patch("openadapt_tray.app.pystray")
+    @patch("openadapt_tray.app.get_platform_handler")
+    def test_open_grounding_settings_opens_dashboard(
+        self, mock_platform, mock_pystray
+    ):
+        """open_grounding_settings routes to the cloud dashboard settings page."""
+        from openadapt_tray.app import TrayApplication
+
+        mock_platform.return_value = MagicMock()
+        mock_pystray.Icon.return_value = MagicMock()
+
+        config = TrayConfig(hosted_url="https://app.openadapt.ai")
+        app = TrayApplication(config=config)
+
+        with patch("openadapt_tray.app.webbrowser.open") as mock_open:
+            app.open_grounding_settings()
+            mock_open.assert_called_once_with(
+                "https://app.openadapt.ai/dashboard/settings"
+            )

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -49,6 +49,34 @@ class TestMenuBuilder:
         # pystray.Menu is the expected type
         assert menu is not None
 
+    def _menu_labels(self, menu):
+        """Collect the text of every top-level menu item."""
+        labels = []
+        for item in menu.items:
+            try:
+                labels.append(str(item.text))
+            except Exception:
+                labels.append("")
+        return labels
+
+    def test_grounding_settings_item_present(self):
+        """The menu exposes a governed 'Grounding Model...' entry point."""
+        app = self.create_mock_app()
+        builder = MenuBuilder(app)
+
+        menu = builder.build()
+
+        assert any("Grounding Model" in label for label in self._menu_labels(menu))
+
+    def test_grounding_settings_item_routes_to_app(self):
+        """Clicking the grounding item calls app.open_grounding_settings."""
+        app = self.create_mock_app()
+        builder = MenuBuilder(app)
+
+        builder._open_grounding_settings()
+
+        app.open_grounding_settings.assert_called_once()
+
     def test_recording_item_when_idle(self):
         """Test recording item shows 'Start Recording' when idle."""
         app = self.create_mock_app(AppState(state=TrayState.IDLE))


### PR DESCRIPTION
## What

Adds a **"Grounding Model..."** item to the tray menu (under "Settings...") that opens the canonical governed editor at `{hosted_url}/dashboard/settings`.

Part of the cross-repo grounding-model settings work (cloud is the canonical editor; desktop renders it read-only). Based on `feat/hosted-rewire` (which has the hosted menu).

## Governance

The grounding model is an admin-scoped, off-by-default **egress** capability governed by the cloud control plane (Tier-3 policy). The tray never edits governed config locally — it routes to the cloud dashboard where an org admin can change it and members see it read-only. This mirrors the existing `Login...` pattern (which opens the ingest settings page).

## Changes

- `app.py`: `open_grounding_settings()` → opens `/dashboard/settings`.
- `menu.py`: `"Grounding Model..."` item + `_open_grounding_settings` handler.
- tests: item present in the built menu + routes to the app method; the app method opens the correct dashboard URL.

## Gates

`ruff` clean; menu + app suites green (140 passed, 2 skipped). The pre-existing `test_release_contract.py` collection error (missing `scripts` module on path) is unrelated to this change and reproduces on the base branch.

## Remaining sync hook (documented, not faked)

The tray intentionally has no local write path for governed config. The effective grounding config is resolved by the cloud control plane (openadapt-cloud `GET /api/policy/effective`) and, on the desktop, fetched fail-closed by the engine (`engine/policy.py`, openadapt-desktop #32). The tray only needs the browser entry point.

Founder-review requested (compliance-sensitive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM