### PR TITLE
chore(deps): bump github/codeql-action init+analyze to v4.37.3 together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,11 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    # github/codeql-action/init and .../analyze must run at the SAME version;
+    # a run with mismatched versions aborts with "Loaded a configuration file
+    # for version X, but running version Y". Ungrouped, Dependabot opens one
+    # PR per sub-action, so each one is red on its own and neither can merge.
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Dependabot opened `github/codeql-action/init` and `github/codeql-action/analyze`
as two separate PRs. Each bumps only one half of the pair, so its own CI run
executes `init` and `analyze` at different versions and the analyze step aborts:

```
##[error]Loaded a configuration file for version '4.37.3', but running version '4.37.1'
CodeQL job status was configuration error.
```

Neither split PR can ever go green, and merging one would redden `main` until the
other landed. This bumps both halves in one commit instead, so the pair stays in
lockstep.

`e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` is the commit `github/codeql-action`
tag `v4.37.3` points at. The SHA-pin + trailing-version-comment convention is
preserved.

The `dependabot.yml` group stops this recurring: future `codeql-action` bumps
arrive as a single PR covering every sub-action.