### PR TITLE
chore: gitignore .private/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,7 @@ Thumbs.db
 
 # Project specific
 *.log
+
+# Never-publish workspace material (strategy, prospect research, counsel packs,
+# personal contact details). Created ad hoc; must never reach a remote.
+.private/


### PR DESCRIPTION
`.private/` is the workspace-wide convention for material that must never be published (strategy, prospect research, funding applications, counsel packs, personal contact details, benchmark corpora). It was not gitignored in this repository, so a `.private/` directory created inside this checkout — which happens routinely — was one stray `git add` away from being committed and pushed.

This adds the single rule plus a short comment. Nothing else is ignored.

Verified before opening: no `.private/` path is tracked in this repository, so the rule takes effect immediately rather than being a no-op over an already-tracked file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM