### PR TITLE
fix: keep tray command failures visible

### DIFF
--- a/src/openadapt_tray/app.py
+++ b/src/openadapt_tray/app.py
@@ -409,8 +409,11 @@ class TrayApplication:
 
     def _open_browser(self, url: str, failure_title: str) -> bool:
         """Open a URL and keep a missing browser distinct from a successful open."""
-        if webbrowser.open(url):
-            return True
+        try:
+            if webbrowser.open(url):
+                return True
+        except Exception as e:
+            print(f"Failed to open {url}: {e}")
         self.notifications.show(
             failure_title,
             f"No usable browser opened. Open {url} manually.",

--- a/src/openadapt_tray/app.py
+++ b/src/openadapt_tray/app.py
@@ -17,7 +17,12 @@ import webbrowser
 import pystray
 
 from openadapt_tray.config import ConfigLoadError, TrayConfig
-from openadapt_tray.hosted import CountResult, HostedPoller, route_break_click
+from openadapt_tray.hosted import (
+    CountResult,
+    HostedPoller,
+    InvalidCountPayload,
+    route_break_click,
+)
 from openadapt_tray.icons import IconManager
 from openadapt_tray.ipc import IPCClient, IPCMessageType
 from openadapt_tray.menu import MenuBuilder
@@ -95,6 +100,7 @@ class TrayApplication:
         self.notifications.set_tray_icon(self.icon)
 
         # Register state change handler
+        self._last_notified_tray_state = self.state.current.state
         self.state.add_listener(self._on_state_change)
 
         # Register IPC handlers
@@ -174,6 +180,10 @@ class TrayApplication:
         Args:
             state: Current application state.
         """
+        if state.state == self._last_notified_tray_state:
+            return
+        self._last_notified_tray_state = state.state
+
         messages = {
             TrayState.RECORDING: (
                 "Recording Started",
@@ -323,7 +333,11 @@ class TrayApplication:
             return
 
         self.state.transition(TrayState.RECORDING_STOPPING)
-        self.ipc.send_stop_recording()
+        if not self.ipc.send_stop_recording():
+            self.state.transition(
+                TrayState.ERROR,
+                error_message="Failed to send stop-recording command.",
+            )
         # The desktop confirms via RECORDING_STOPPED (then COMPILE_PROGRESS).
 
     # --- quick actions ------------------------------------------------------
@@ -331,7 +345,8 @@ class TrayApplication:
     def open_desktop_app(self) -> None:
         """Open (or focus) the desktop app's workflow library."""
         if self.ipc.is_connected():
-            self.ipc.send_open_workflow_library()
+            if not self.ipc.send_open_workflow_library():
+                self._report_desktop_open_failure()
             return
         # Not connected — launch/connect, then ask it to open the library.
         threading.Thread(
@@ -342,11 +357,24 @@ class TrayApplication:
     def _open_desktop_app_async(self) -> None:
         """Background helper for :meth:`open_desktop_app`."""
         if self.ensure_desktop_connection():
-            self.ipc.send_open_workflow_library()
+            if not self.ipc.send_open_workflow_library():
+                self._report_desktop_open_failure()
+        else:
+            self._report_desktop_open_failure()
 
-    def open_cloud_dashboard(self) -> None:
+    def _report_desktop_open_failure(self) -> None:
+        """Report that the workflow-library command did not reach the desktop."""
+        self.notifications.show(
+            "Could not open the desktop app",
+            "The tray could not send the workflow-library command.",
+        )
+
+    def open_cloud_dashboard(self) -> bool:
         """Open the hosted cloud dashboard in the system browser."""
-        webbrowser.open(self.config.hosted_url)
+        return self._open_browser(
+            self.config.hosted_url,
+            "Could not open the cloud dashboard",
+        )
 
     def open_needs_attention(self) -> bool:
         """Route a needs-attention click by deployment lane (§3c).
@@ -367,27 +395,48 @@ class TrayApplication:
             )
         return routed
 
-    def login(self) -> None:
+    def login(self) -> bool:
         """Start the hosted login flow.
 
         The tray does not implement auth; it opens the ingest-token settings
         page (the desktop app owns the interactive providers) so the user can
         mint/paste a token that lands in the shared keychain.
         """
-        webbrowser.open(
-            f"{self.config.hosted_url.rstrip('/')}/dashboard/settings/ingest"
+        return self._open_browser(
+            f"{self.config.hosted_url.rstrip('/')}/dashboard/settings/ingest",
+            "Could not open login settings",
         )
 
-    def pause_sync(self) -> None:
-        """Ask the desktop to pause the upload/sync queue."""
-        if self.ipc.is_connected():
-            self.ipc.send_pause_sync()
-        self.state.set_sync_state(SyncState.SYNCED)
+    def _open_browser(self, url: str, failure_title: str) -> bool:
+        """Open a URL and keep a missing browser distinct from a successful open."""
+        if webbrowser.open(url):
+            return True
+        self.notifications.show(
+            failure_title,
+            f"No usable browser opened. Open {url} manually.",
+        )
+        return False
 
-    def resume_sync(self) -> None:
+    def pause_sync(self) -> bool:
+        """Ask the desktop to pause the upload/sync queue."""
+        if not self.ipc.is_connected() or not self.ipc.send_pause_sync():
+            self.notifications.show(
+                "Could not pause sync",
+                "The desktop app did not accept the pause command.",
+            )
+            return False
+        self.state.set_sync_state(SyncState.SYNCED)
+        return True
+
+    def resume_sync(self) -> bool:
         """Ask the desktop to resume the upload/sync queue."""
-        if self.ipc.is_connected():
-            self.ipc.send_resume_sync()
+        if not self.ipc.is_connected() or not self.ipc.send_resume_sync():
+            self.notifications.show(
+                "Could not resume sync",
+                "The desktop app did not accept the resume command.",
+            )
+            return False
+        return True
 
     def _report_config_error(self) -> None:
         """Tell the user when the tray is running on defaults it did not choose."""
@@ -453,7 +502,7 @@ class TrayApplication:
             self._apply_sync_state(sync)
 
         if "break_count" in data:
-            self.state.set_break_count(data.get("break_count") or 0)
+            self._apply_break_count(data.get("break_count"))
 
         state_name = data.get("state")
         if state_name:
@@ -483,7 +532,16 @@ class TrayApplication:
     def _on_ipc_break_count(self, message) -> None:
         """Handle a break-count event pushed from the desktop."""
         data = message.data or {}
-        self.state.set_break_count(data.get("count") or 0)
+        self._apply_break_count(data.get("count"))
+
+    def _apply_break_count(self, value: object) -> None:
+        """Apply a validated count without turning an unreadable value into zero."""
+        try:
+            result = CountResult.from_payload({"count": value})
+        except InvalidCountPayload as e:
+            print(f"Ignored unusable IPC break count: {e}")
+            return
+        self.state.set_break_count(result.count)
 
     def _apply_sync_state(self, name: str | None) -> None:
         """Map a sync-state name from IPC onto the SyncState channel."""

--- a/src/openadapt_tray/hosted.py
+++ b/src/openadapt_tray/hosted.py
@@ -93,12 +93,12 @@ class CountResult:
             )
         if "count" not in payload:
             raise InvalidCountPayload("response body has no 'count' field")
-        try:
-            count = int(payload["count"])
-        except (TypeError, ValueError) as e:
-            raise InvalidCountPayload(
-                f"'count' is not an integer: {payload['count']!r}"
-            ) from e
+        count = payload["count"]
+        # JSON booleans are Python integers, and ``int(1.9)`` truncates. Both
+        # conversions can turn an unreadable response into a confident badge
+        # value, including the unsafe ``false`` -> ``0`` all-clear.
+        if isinstance(count, bool) or not isinstance(count, int):
+            raise InvalidCountPayload(f"'count' is not an integer: {count!r}")
         if count < 0:
             raise InvalidCountPayload(f"'count' is negative: {count}")
         return cls(
@@ -321,7 +321,11 @@ def route_break_click(
             print(f"Failed to route byoc break click to desktop: {e}")
     # webbrowser.open returns False when it could not find or start a browser.
     # Discarding that made a dead click indistinguishable from a served one.
-    opened = webbrowser.open(f"{config.hosted_url.rstrip('/')}/dashboard")
+    try:
+        opened = webbrowser.open(f"{config.hosted_url.rstrip('/')}/dashboard")
+    except Exception as e:
+        print(f"Could not open the hosted dashboard: {e}")
+        return False
     if not opened:
         print("Could not open the hosted dashboard: no usable browser")
     return bool(opened)

--- a/src/openadapt_tray/hosted.py
+++ b/src/openadapt_tray/hosted.py
@@ -314,8 +314,9 @@ def route_break_click(
     # unreachable (or there is no IPC client to reach it with).
     if config.deployment_lane == "byoc" and ipc_client is not None:
         try:
-            ipc_client.send_open_teach()
-            return True
+            if ipc_client.send_open_teach():
+                return True
+            print("Desktop refused the open-teach command; trying the dashboard")
         except Exception as e:
             print(f"Failed to route byoc break click to desktop: {e}")
     # webbrowser.open returns False when it could not find or start a browser.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -425,6 +425,17 @@ class TestOpenActionsReportDeadEnds:
 
         app.notifications.show.assert_called_once()
 
+    def test_browser_exception_is_reported(self):
+        app = _make_test_app()
+        app.notifications = MagicMock()
+
+        with patch(
+            "openadapt_tray.app.webbrowser.open", side_effect=OSError("no browser")
+        ):
+            assert app.open_cloud_dashboard() is False
+
+        app.notifications.show.assert_called_once()
+
 
 class TestFailedIPCResultsStayFailed:
     """A False command result means that the tray sent no command."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,7 +5,19 @@ from unittest.mock import MagicMock, patch
 
 from openadapt_tray.config import ConfigLoadError, TrayConfig
 from openadapt_tray.platform.base import DialogUnavailableError
-from openadapt_tray.state import TrayState
+from openadapt_tray.state import SyncState, TrayState
+
+
+def _make_test_app():
+    """Build an app without platform or tray side effects."""
+    from openadapt_tray.app import TrayApplication
+
+    with patch("openadapt_tray.app.get_platform_handler") as platform, patch(
+        "openadapt_tray.app.pystray"
+    ) as pystray:
+        platform.return_value = MagicMock()
+        pystray.Icon.return_value = MagicMock()
+        return TrayApplication(config=TrayConfig())
 
 
 class TestTrayApplicationInit:
@@ -97,11 +109,23 @@ class TestRecordingControls:
         app.state.transition(TrayState.RECORDING, current_capture="test")
 
         with patch.object(app.ipc, "send_stop_recording") as mock_stop:
+            mock_stop.return_value = True
             app.stop_recording()
             mock_stop.assert_called_once()
 
         # The tray waits for the desktop's RECORDING_STOPPED event.
         assert app.state.current.state == TrayState.RECORDING_STOPPING
+
+    def test_failed_stop_command_enters_error(self):
+        """A command that was not sent must not render as stopping."""
+        app = _make_test_app()
+        app.state.transition(TrayState.RECORDING, current_capture="test")
+
+        with patch.object(app.ipc, "send_stop_recording", return_value=False):
+            app.stop_recording()
+
+        assert app.state.current.state == TrayState.ERROR
+        assert "stop-recording" in (app.state.current.error_message or "")
 
     @patch("openadapt_tray.app.pystray")
     @patch("openadapt_tray.app.get_platform_handler")
@@ -191,6 +215,15 @@ class TestStateNotifications:
         with patch.object(app.notifications, "show") as mock_show:
             app.state.transition(TrayState.RECORDING, current_capture="test")
             mock_show.assert_not_called()
+
+    def test_sync_change_does_not_claim_recording_stopped(self):
+        """An orthogonal sync update is not a recording completion."""
+        app = _make_test_app()
+
+        with patch.object(app.notifications, "show") as mock_show:
+            app.state.set_sync_state(SyncState.SYNCING)
+
+        mock_show.assert_not_called()
 
 
 class TestQuit:
@@ -369,3 +402,83 @@ class TestNeedsAttentionClickReportsDeadEnds:
         with patch("openadapt_tray.app.route_break_click", return_value=True):
             assert app.open_needs_attention() is True
         app.notifications.show.assert_not_called()
+
+
+class TestOpenActionsReportDeadEnds:
+    def test_connected_desktop_command_failure_is_reported(self):
+        app = _make_test_app()
+        app.notifications = MagicMock()
+        app.ipc = MagicMock()
+        app.ipc.is_connected.return_value = True
+        app.ipc.send_open_workflow_library.return_value = False
+
+        app.open_desktop_app()
+
+        app.notifications.show.assert_called_once()
+
+    def test_browser_failure_is_not_reported_as_opened(self):
+        app = _make_test_app()
+        app.notifications = MagicMock()
+
+        with patch("openadapt_tray.app.webbrowser.open", return_value=False):
+            assert app.open_cloud_dashboard() is False
+
+        app.notifications.show.assert_called_once()
+
+
+class TestFailedIPCResultsStayFailed:
+    """A False command result means that the tray sent no command."""
+
+    def test_failed_pause_does_not_report_synced(self):
+        app = _make_test_app()
+        app.notifications = MagicMock()
+        app.state.set_sync_state(SyncState.SYNCING)
+        app.ipc = MagicMock()
+        app.ipc.is_connected.return_value = True
+        app.ipc.send_pause_sync.return_value = False
+
+        assert app.pause_sync() is False
+        assert app.state.current.sync_state == SyncState.SYNCING
+        app.notifications.show.assert_called_once()
+
+    def test_successful_pause_updates_sync_state(self):
+        app = _make_test_app()
+        app.state.set_sync_state(SyncState.SYNCING)
+        app.ipc = MagicMock()
+        app.ipc.is_connected.return_value = True
+        app.ipc.send_pause_sync.return_value = True
+
+        assert app.pause_sync() is True
+        assert app.state.current.sync_state == SyncState.SYNCED
+
+    def test_failed_resume_is_reported(self):
+        app = _make_test_app()
+        app.notifications = MagicMock()
+        app.ipc = MagicMock()
+        app.ipc.is_connected.return_value = True
+        app.ipc.send_resume_sync.return_value = False
+
+        assert app.resume_sync() is False
+        app.notifications.show.assert_called_once()
+
+
+class TestUnreadableIPCBreakCounts:
+    """An unreadable pushed count must not clear the last known badge."""
+
+    def test_missing_count_keeps_last_known_value(self):
+        app = _make_test_app()
+        app.state.set_break_count(4)
+        message = MagicMock(data={})
+
+        app._on_ipc_break_count(message)
+
+        assert app.state.current.break_count == 4
+
+    def test_invalid_status_count_keeps_last_known_value(self):
+        app = _make_test_app()
+        app.state.set_break_count(4)
+        message = MagicMock(data={"break_count": "unknown"})
+
+        app._on_ipc_status_update(message)
+
+        assert app.state.current.break_count == 4

--- a/tests/test_hosted.py
+++ b/tests/test_hosted.py
@@ -256,6 +256,14 @@ class TestRouteBreakClick:
             route_break_click(cfg, ipc_client=None)
         mock_open.assert_called_once()
 
+    def test_browser_exception_reports_no_route(self):
+        cfg = make_config(deployment_lane="cloud")
+        with patch(
+            "openadapt_tray.hosted.webbrowser.open",
+            side_effect=OSError("no browser"),
+        ):
+            assert route_break_click(cfg, ipc_client=None) is False
+
 
 class TestUnreadableCountPayload:
     """A body we cannot read is NOT a count of zero.
@@ -278,6 +286,11 @@ class TestUnreadableCountPayload:
     def test_non_numeric_count_raises(self):
         with pytest.raises(InvalidCountPayload):
             CountResult.from_payload({"count": "lots"})
+
+    @pytest.mark.parametrize("value", [False, True, 0.0, 1.9, "2"])
+    def test_non_json_integer_count_raises(self, value):
+        with pytest.raises(InvalidCountPayload):
+            CountResult.from_payload({"count": value})
 
     def test_negative_count_raises(self):
         with pytest.raises(InvalidCountPayload):

--- a/tests/test_hosted.py
+++ b/tests/test_hosted.py
@@ -233,10 +233,22 @@ class TestRouteBreakClick:
     def test_byoc_lane_routes_to_desktop(self):
         cfg = make_config(deployment_lane="byoc")
         ipc = MagicMock()
+        ipc.send_open_teach.return_value = True
         with patch("openadapt_tray.hosted.webbrowser.open") as mock_open:
-            route_break_click(cfg, ipc_client=ipc)
+            assert route_break_click(cfg, ipc_client=ipc) is True
         ipc.send_open_teach.assert_called_once()
         mock_open.assert_not_called()
+
+    def test_byoc_command_failure_falls_back_to_dashboard(self):
+        """A False IPC result means the local teach view did not open."""
+        cfg = make_config(deployment_lane="byoc")
+        ipc = MagicMock()
+        ipc.send_open_teach.return_value = False
+        with patch(
+            "openadapt_tray.hosted.webbrowser.open", return_value=True
+        ) as mock_open:
+            assert route_break_click(cfg, ipc_client=ipc) is True
+        mock_open.assert_called_once_with("https://example.test/dashboard")
 
     def test_byoc_falls_back_to_dashboard_when_no_desktop(self):
         cfg = make_config(deployment_lane="byoc")


### PR DESCRIPTION
## What changed

- Treat a `False` IPC result as a failed command for stop, open, teach, pause, and resume actions.
- Keep the last valid needs-attention count when an IPC payload is missing or unreadable.
- Report browser and desktop open failures to the user.
- Emit recording notifications only when the recording lifecycle changes.

## Why

Several tray paths discarded a failure result and then rendered a success-shaped state. A failed stop command could remain at `RECORDING_STOPPING`. A failed pause command could report `SYNCED`. An invalid count could clear the badge to zero. An unrelated sync update could also emit `Recording Stopped`.

## Validation

- `uv run --extra dev pytest tests -q` — 208 passed, 2 skipped
- `uv run --extra dev ruff check .`
- `uv build --wheel --out-dir /tmp/oa-tray-failure-sweep-dist`
- `git diff --check`
